### PR TITLE
Feature/30 modify report layout

### DIFF
--- a/CatchMe/CatchMe.xcodeproj/project.pbxproj
+++ b/CatchMe/CatchMe.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		EDBDC7FF2694444300CDF1B2 /* ReportPopupVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBDC7FE2694444300CDF1B2 /* ReportPopupVC.swift */; };
 		EDBDC8012694481A00CDF1B2 /* PopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBDC8002694481A00CDF1B2 /* PopupView.swift */; };
 		EDBDC803269456A800CDF1B2 /* CatchuCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBDC802269456A800CDF1B2 /* CatchuCVC.swift */; };
+		EDBDC8052694B70C00CDF1B2 /* AddCatchuVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBDC8042694B70C00CDF1B2 /* AddCatchuVC.swift */; };
 		EDC3780C2691D3CC007C53F2 /* ReportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC3780B2691D3CC007C53F2 /* ReportView.swift */; };
 		EDD12C94268EAD1F00DF766A /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD12C93268EAD1F00DF766A /* BackButton.swift */; };
 		EDD12C96268EB16800DF766A /* XmarkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD12C95268EB16800DF766A /* XmarkButton.swift */; };
@@ -98,6 +99,7 @@
 		EDBDC7FE2694444300CDF1B2 /* ReportPopupVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportPopupVC.swift; sourceTree = "<group>"; };
 		EDBDC8002694481A00CDF1B2 /* PopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupView.swift; sourceTree = "<group>"; };
 		EDBDC802269456A800CDF1B2 /* CatchuCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatchuCVC.swift; sourceTree = "<group>"; };
+		EDBDC8042694B70C00CDF1B2 /* AddCatchuVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCatchuVC.swift; sourceTree = "<group>"; };
 		EDC3780B2691D3CC007C53F2 /* ReportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportView.swift; sourceTree = "<group>"; };
 		EDD12C93268EAD1F00DF766A /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
 		EDD12C95268EB16800DF766A /* XmarkButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XmarkButton.swift; sourceTree = "<group>"; };
@@ -262,6 +264,7 @@
 				EDD12CA3268EB80300DF766A /* CharacterVC.swift */,
 				EDD12CA7268EB84C00DF766A /* ReportVC.swift */,
 				EDBDC7FE2694444300CDF1B2 /* ReportPopupVC.swift */,
+				EDBDC8042694B70C00CDF1B2 /* AddCatchuVC.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -552,6 +555,7 @@
 			files = (
 				EDD12C98268EB27500DF766A /* BottomButton.swift in Sources */,
 				EDBBFCCF26934AC300443077 /* CalendarTitleView.swift in Sources */,
+				EDBDC8052694B70C00CDF1B2 /* AddCatchuVC.swift in Sources */,
 				5B0850642691A1A4008F40B2 /* CharacterHeaderView.swift in Sources */,
 				EDD12C9E268EB71000DF766A /* MainVC.swift in Sources */,
 				EDD12C96268EB16800DF766A /* XmarkButton.swift in Sources */,

--- a/CatchMe/CatchMe/Resource/Storyboards/Character.storyboard
+++ b/CatchMe/CatchMe/Resource/Storyboards/Character.storyboard
@@ -23,6 +23,21 @@
             </objects>
             <point key="canvasLocation" x="114" y="116"/>
         </scene>
+        <!--Add CatchuVC-->
+        <scene sceneID="uIW-d6-UGY">
+            <objects>
+                <viewController storyboardIdentifier="AddCatchuVC" id="QBA-FL-kiO" customClass="AddCatchuVC" customModule="CatchMe" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="ym8-0D-GWf">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="Xvo-Ai-Meg"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="hEC-Ig-dtL" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="113" y="903"/>
+        </scene>
     </scenes>
     <resources>
         <systemColor name="systemBackgroundColor">

--- a/CatchMe/CatchMe/Source/Components/Report/ReportView.swift
+++ b/CatchMe/CatchMe/Source/Components/Report/ReportView.swift
@@ -31,24 +31,14 @@ class ReportView: UIView {
         addSubviews([titleView, characterView])
         
         characterView.snp.makeConstraints { make in
-            if UIScreen.main.hasNotch {
-                make.bottom.equalToSuperview().inset(31)
-                make.leading.trailing.equalToSuperview().inset(28)
-            } else {
-                make.bottom.equalToSuperview().inset(21)
-                make.leading.trailing.equalToSuperview().inset(20)
-            }
+            make.bottom.equalToSuperview().inset(UIScreen.main.hasNotch ? 31 : 21)
+            make.leading.trailing.equalToSuperview().inset(UIScreen.main.hasNotch ? 28 : 20)
             make.height.equalTo(136)
         }
         
         titleView.snp.makeConstraints { make in
-            if UIScreen.main.hasNotch {
-                make.trailing.equalToSuperview().inset(28)
-                make.bottom.equalToSuperview().inset(188)
-            } else {
-                make.trailing.equalToSuperview().inset(20)
-                make.bottom.equalToSuperview().inset(172)
-            }
+            make.trailing.equalToSuperview().inset(UIScreen.main.hasNotch ? 28 : 20)
+            make.bottom.equalToSuperview().inset(UIScreen.main.hasNotch ? 188 : 172)
             make.height.equalTo(52)
         }
     }

--- a/CatchMe/CatchMe/Source/Components/Report/ReportView.swift
+++ b/CatchMe/CatchMe/Source/Components/Report/ReportView.swift
@@ -31,14 +31,24 @@ class ReportView: UIView {
         addSubviews([titleView, characterView])
         
         characterView.snp.makeConstraints { make in
-            make.bottom.equalToSuperview().inset(31)
-            make.leading.trailing.equalToSuperview().inset(28)
+            if UIScreen.main.hasNotch {
+                make.bottom.equalToSuperview().inset(31)
+                make.leading.trailing.equalToSuperview().inset(28)
+            } else {
+                make.bottom.equalToSuperview().inset(21)
+                make.leading.trailing.equalToSuperview().inset(20)
+            }
             make.height.equalTo(136)
         }
         
         titleView.snp.makeConstraints { make in
-            make.trailing.equalToSuperview().inset(28)
-            make.bottom.equalToSuperview().inset(188)
+            if UIScreen.main.hasNotch {
+                make.trailing.equalToSuperview().inset(28)
+                make.bottom.equalToSuperview().inset(188)
+            } else {
+                make.trailing.equalToSuperview().inset(20)
+                make.bottom.equalToSuperview().inset(172)
+            }
             make.height.equalTo(52)
         }
     }

--- a/CatchMe/CatchMe/Source/Extensions/UIColor+Extension.swift
+++ b/CatchMe/CatchMe/Source/Extensions/UIColor+Extension.swift
@@ -23,6 +23,10 @@ extension UIColor {
     @nonobjc class var pink200: UIColor {
         return UIColor(red: 236.0 / 255.0, green: 71.0 / 255.0, blue: 123.0 / 255.0, alpha: 1.0)
     }
+    
+    @nonobjc class var pink210: UIColor {
+        return UIColor(red: 1.0, green: 72.0 / 255.0, blue: 130.0 / 255.0, alpha: 1.0)
+    }
 
     @nonobjc class var white: UIColor {
         return UIColor(white: 252.0 / 255.0, alpha: 1.0)
@@ -46,6 +50,10 @@ extension UIColor {
 
     @nonobjc class var black300: UIColor {
         return UIColor(white: 47.0 / 255.0, alpha: 1.0)
+    }
+    
+    @nonobjc class var gray50: UIColor {
+        return UIColor(white: 92.0 / 255.0, alpha: 1.0)
     }
 
     @nonobjc class var gray100: UIColor {
@@ -74,5 +82,9 @@ extension UIColor {
 
     @nonobjc class var blue100: UIColor {
         return UIColor(red: 0.0, green: 120.0 / 255.0, blue: 212.0 / 255.0, alpha: 1.0)
+    }
+    
+    @nonobjc class var logo100: UIColor {
+        return UIColor(red: 181.0 / 255.0, green: 24.0 / 255.0, blue: 73.0 / 255.0, alpha: 1.0)
     }
 }

--- a/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
@@ -1,0 +1,29 @@
+//
+//  AddCatchuVC.swift
+//  CatchMe
+//
+//  Created by SHIN YOON AH on 2021/07/07.
+//
+
+import UIKit
+
+class AddCatchuVC: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/CatchMe/CatchMe/Source/ViewControllers/ReportPopupVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/ReportPopupVC.swift
@@ -24,11 +24,17 @@ class ReportPopupVC: UIViewController {
     private func setupLayout() {
         view.addSubview(popupView)
         
+        let height = UIScreen.main.bounds.size.height/667
+        
         popupView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide).inset(UIScreen.main.bounds.size.height * 0.2)
             make.centerX.equalToSuperview()
-            make.width.equalTo(280)
-            make.height.equalTo(415)
+            make.width.equalTo(280 * (UIScreen.main.bounds.size.width/375))
+            if height == 1 {
+                make.height.equalTo(415)
+            } else {
+                make.height.equalTo((415 * height)*0.85)
+            }
         }
     }
 }

--- a/CatchMe/CatchMe/Source/ViewControllers/ReportPopupVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/ReportPopupVC.swift
@@ -24,16 +24,16 @@ class ReportPopupVC: UIViewController {
     private func setupLayout() {
         view.addSubview(popupView)
         
-        let height = UIScreen.main.bounds.size.height/667
+        let height = UIScreen.main.bounds.size.height / 667
         
         popupView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide).inset(UIScreen.main.bounds.size.height * 0.2)
             make.centerX.equalToSuperview()
-            make.width.equalTo(280 * (UIScreen.main.bounds.size.width/375))
+            make.width.equalTo(280 * (UIScreen.main.bounds.size.width / 375))
             if height == 1 {
                 make.height.equalTo(415)
             } else {
-                make.height.equalTo((415 * height)*0.85)
+                make.height.equalTo((415 * height) * 0.85)
             }
         }
     }

--- a/CatchMe/CatchMe/Source/ViewControllers/ReportPopupVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/ReportPopupVC.swift
@@ -30,11 +30,7 @@ class ReportPopupVC: UIViewController {
             make.top.equalTo(view.safeAreaLayoutGuide).inset(UIScreen.main.bounds.size.height * 0.2)
             make.centerX.equalToSuperview()
             make.width.equalTo(280 * (UIScreen.main.bounds.size.width / 375))
-            if height == 1 {
-                make.height.equalTo(415)
-            } else {
-                make.height.equalTo((415 * height) * 0.85)
-            }
+            make.height.equalTo(height == 1 ? 415 : (415 * height) * 0.85)
         }
     }
 }

--- a/CatchMe/CatchMe/Source/ViewControllers/ReportVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/ReportVC.swift
@@ -93,7 +93,11 @@ class ReportVC: UIViewController {
         
         calendarTitleView.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.top.equalTo(reportView.snp.bottom).offset(37)
+            if UIScreen.main.hasNotch {
+                make.top.equalTo(reportView.snp.bottom).offset(37)
+            } else {
+                make.top.equalTo(reportView.snp.bottom).offset(11)
+            }
         }
         
         previousButton.snp.makeConstraints { make in
@@ -110,13 +114,22 @@ class ReportVC: UIViewController {
         
         weekdayCollectionView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview()
-            make.top.equalTo(calendarTitleView.snp.bottom).offset(14)
-            make.height.equalTo(43)
+            if UIScreen.main.hasNotch {
+                make.top.equalTo(calendarTitleView.snp.bottom).offset(14)
+                make.height.equalTo(43)
+            } else {
+                make.top.equalTo(calendarTitleView.snp.bottom).offset(11)
+                make.height.equalTo(34)
+            }
         }
         
         dateCollectionView.snp.makeConstraints { make in
             make.leading.trailing.bottom.equalToSuperview()
-            make.top.equalTo(weekdayCollectionView.snp.bottom).offset(8)
+            if UIScreen.main.hasNotch {
+                make.top.equalTo(weekdayCollectionView.snp.bottom).offset(8)
+            } else {
+                make.top.equalTo(weekdayCollectionView.snp.bottom)
+            }
         }
     }
     
@@ -264,13 +277,24 @@ extension ReportVC: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout:UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let boundSize = UIScreen.main.bounds.size.width - 32 - 24
         var cellSize = 0
+        var height = 0
         
         switch collectionView {
         case weekdayCollectionView:
             cellSize = Int(boundSize / 7)
-            return CGSize(width: cellSize, height: 43)
+            if UIScreen.main.hasNotch {
+                height = 43
+            } else {
+                height = 34
+            }
+            return CGSize(width: cellSize, height: height)
         default:
             cellSize = Int(boundSize / 7)
+            if UIScreen.main.hasNotch {
+                height = 51
+            } else {
+                height = 48
+            }
             return CGSize(width: cellSize, height: 51)
         }
     }
@@ -280,7 +304,10 @@ extension ReportVC: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        return 3
+        if UIScreen.main.hasNotch {
+            return 3
+        }
+        return 0
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout:UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {

--- a/CatchMe/CatchMe/Source/ViewControllers/ReportVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/ReportVC.swift
@@ -87,8 +87,13 @@ class ReportVC: UIViewController {
         }
         
         backButton.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(55)
-            make.leading.equalToSuperview().inset(14)
+            if UIScreen.main.hasNotch {
+                make.top.equalToSuperview().inset(55)
+                make.leading.equalToSuperview().inset(14)
+            } else {
+                make.top.equalToSuperview().inset(41)
+                make.leading.equalToSuperview().inset(3)
+            }
         }
         
         calendarTitleView.snp.makeConstraints { make in

--- a/CatchMe/CatchMe/Source/ViewControllers/ReportVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/ReportVC.swift
@@ -295,7 +295,7 @@ extension ReportVC: UICollectionViewDelegateFlowLayout {
             } else {
                 height = 48
             }
-            return CGSize(width: cellSize, height: 51)
+            return CGSize(width: cellSize, height: height)
         }
     }
     

--- a/CatchMe/CatchMe/Source/ViewControllers/ReportVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/ReportVC.swift
@@ -87,22 +87,13 @@ class ReportVC: UIViewController {
         }
         
         backButton.snp.makeConstraints { make in
-            if UIScreen.main.hasNotch {
-                make.top.equalToSuperview().inset(55)
-                make.leading.equalToSuperview().inset(14)
-            } else {
-                make.top.equalToSuperview().inset(41)
-                make.leading.equalToSuperview().inset(3)
-            }
+            make.top.equalToSuperview().inset(UIScreen.main.hasNotch ? 55 : 41)
+            make.leading.equalToSuperview().inset(UIScreen.main.hasNotch ? 14 : 3)
         }
         
         calendarTitleView.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            if UIScreen.main.hasNotch {
-                make.top.equalTo(reportView.snp.bottom).offset(37)
-            } else {
-                make.top.equalTo(reportView.snp.bottom).offset(11)
-            }
+            make.top.equalTo(reportView.snp.bottom).offset(UIScreen.main.hasNotch ? 37 : 11)
         }
         
         previousButton.snp.makeConstraints { make in
@@ -119,22 +110,13 @@ class ReportVC: UIViewController {
         
         weekdayCollectionView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview()
-            if UIScreen.main.hasNotch {
-                make.top.equalTo(calendarTitleView.snp.bottom).offset(14)
-                make.height.equalTo(43)
-            } else {
-                make.top.equalTo(calendarTitleView.snp.bottom).offset(11)
-                make.height.equalTo(34)
-            }
+            make.top.equalTo(calendarTitleView.snp.bottom).offset(UIScreen.main.hasNotch ? 14 : 11)
+            make.height.equalTo(UIScreen.main.hasNotch ? 43 : 34)
         }
         
         dateCollectionView.snp.makeConstraints { make in
             make.leading.trailing.bottom.equalToSuperview()
-            if UIScreen.main.hasNotch {
-                make.top.equalTo(weekdayCollectionView.snp.bottom).offset(8)
-            } else {
-                make.top.equalTo(weekdayCollectionView.snp.bottom)
-            }
+            make.top.equalTo(weekdayCollectionView.snp.bottom).offset(UIScreen.main.hasNotch ? 8 : 0)
         }
     }
     
@@ -282,25 +264,14 @@ extension ReportVC: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout:UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let boundSize = UIScreen.main.bounds.size.width - 32 - 24
         var cellSize = 0
-        var height = 0
         
         switch collectionView {
         case weekdayCollectionView:
             cellSize = Int(boundSize / 7)
-            if UIScreen.main.hasNotch {
-                height = 43
-            } else {
-                height = 34
-            }
-            return CGSize(width: cellSize, height: height)
+            return CGSize(width: cellSize, height: UIScreen.main.hasNotch ? 43 : 34)
         default:
             cellSize = Int(boundSize / 7)
-            if UIScreen.main.hasNotch {
-                height = 51
-            } else {
-                height = 48
-            }
-            return CGSize(width: cellSize, height: height)
+            return CGSize(width: cellSize, height: UIScreen.main.hasNotch ? 51 : 48)
         }
     }
     
@@ -309,10 +280,7 @@ extension ReportVC: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        if UIScreen.main.hasNotch {
-            return 3
-        }
-        return 0
+        return UIScreen.main.hasNotch ? 3 : 0
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout:UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {


### PR DESCRIPTION
### 관련 이슈
close #29 
close #30 

### 구현/변경 사항 및 이유
SE2 사이즈에서 캘린더가 잘려버리는 이슈가 있어서 SE2크기일 때 사이즈를 다른 기종과 달리하는 작업을 했습니다.
또한 피그마에 컬러가 추가되어 그 부분을 반영했습니다.

### PR Point
UIScreen.main.hasNotch를 쓰는 코드가 너무 지저분하지 않은지 싶습니다.

### 참고 사항
**추가된 컬러**
<img width="627" alt="스크린샷 2021-07-07 오전 10 52 15" src="https://user-images.githubusercontent.com/55099365/124688235-6660f380-df11-11eb-8138-b379b692c38b.png">

