### PR TITLE
Feature/14 add catchu layout

### DIFF
--- a/CatchMe/CatchMe.xcodeproj/project.pbxproj
+++ b/CatchMe/CatchMe.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		EDB431B226958D1F0008BFB4 /* FirstFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB431B126958D1F0008BFB4 /* FirstFlowView.swift */; };
 		EDB431B72695BA9F0008BFB4 /* CarouselCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB431B62695BA9F0008BFB4 /* CarouselCVC.swift */; };
 		EDB431BB2695F9200008BFB4 /* SecondFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB431BA2695F9200008BFB4 /* SecondFlowView.swift */; };
+		EDB431BD269603210008BFB4 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB431BC269603210008BFB4 /* CustomTextField.swift */; };
 		EDBBFCCB26930C4600443077 /* TitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBBFCCA26930C4600443077 /* TitleView.swift */; };
 		EDBBFCCD2693155F00443077 /* CharacterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBBFCCC2693155F00443077 /* CharacterView.swift */; };
 		EDBBFCCF26934AC300443077 /* CalendarTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBBFCCE26934AC300443077 /* CalendarTitleView.swift */; };
@@ -98,6 +99,7 @@
 		EDB431B126958D1F0008BFB4 /* FirstFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstFlowView.swift; sourceTree = "<group>"; };
 		EDB431B62695BA9F0008BFB4 /* CarouselCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselCVC.swift; sourceTree = "<group>"; };
 		EDB431BA2695F9200008BFB4 /* SecondFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondFlowView.swift; sourceTree = "<group>"; };
+		EDB431BC269603210008BFB4 /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
 		EDBBFCCA26930C4600443077 /* TitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleView.swift; sourceTree = "<group>"; };
 		EDBBFCCC2693155F00443077 /* CharacterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterView.swift; sourceTree = "<group>"; };
 		EDBBFCCE26934AC300443077 /* CalendarTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarTitleView.swift; sourceTree = "<group>"; };
@@ -443,6 +445,7 @@
 				EDD12C93268EAD1F00DF766A /* BackButton.swift */,
 				EDD12C95268EB16800DF766A /* XmarkButton.swift */,
 				EDD12C97268EB27500DF766A /* BottomButton.swift */,
+				EDB431BC269603210008BFB4 /* CustomTextField.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -617,6 +620,7 @@
 				EDD12C9E268EB71000DF766A /* MainVC.swift in Sources */,
 				EDB431B72695BA9F0008BFB4 /* CarouselCVC.swift in Sources */,
 				EDB431B226958D1F0008BFB4 /* FirstFlowView.swift in Sources */,
+				EDB431BD269603210008BFB4 /* CustomTextField.swift in Sources */,
 				EDD12C96268EB16800DF766A /* XmarkButton.swift in Sources */,
 				2BDC1AB026942973008381C3 /* MainCardVC.swift in Sources */,
 				EDBBFCCD2693155F00443077 /* CharacterView.swift in Sources */,

--- a/CatchMe/CatchMe.xcodeproj/project.pbxproj
+++ b/CatchMe/CatchMe.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		EDB431B72695BA9F0008BFB4 /* CarouselCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB431B62695BA9F0008BFB4 /* CarouselCVC.swift */; };
 		EDB431BB2695F9200008BFB4 /* SecondFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB431BA2695F9200008BFB4 /* SecondFlowView.swift */; };
 		EDB431BD269603210008BFB4 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB431BC269603210008BFB4 /* CustomTextField.swift */; };
+		EDB431BF2696325E0008BFB4 /* ThirdFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB431BE2696325E0008BFB4 /* ThirdFlowView.swift */; };
 		EDBBFCCB26930C4600443077 /* TitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBBFCCA26930C4600443077 /* TitleView.swift */; };
 		EDBBFCCD2693155F00443077 /* CharacterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBBFCCC2693155F00443077 /* CharacterView.swift */; };
 		EDBBFCCF26934AC300443077 /* CalendarTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBBFCCE26934AC300443077 /* CalendarTitleView.swift */; };
@@ -100,6 +101,7 @@
 		EDB431B62695BA9F0008BFB4 /* CarouselCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselCVC.swift; sourceTree = "<group>"; };
 		EDB431BA2695F9200008BFB4 /* SecondFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondFlowView.swift; sourceTree = "<group>"; };
 		EDB431BC269603210008BFB4 /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
+		EDB431BE2696325E0008BFB4 /* ThirdFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThirdFlowView.swift; sourceTree = "<group>"; };
 		EDBBFCCA26930C4600443077 /* TitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleView.swift; sourceTree = "<group>"; };
 		EDBBFCCC2693155F00443077 /* CharacterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterView.swift; sourceTree = "<group>"; };
 		EDBBFCCE26934AC300443077 /* CalendarTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarTitleView.swift; sourceTree = "<group>"; };
@@ -423,6 +425,7 @@
 				EDBDC809269585F800CDF1B2 /* CatchuTitleView.swift */,
 				EDB431B126958D1F0008BFB4 /* FirstFlowView.swift */,
 				EDB431BA2695F9200008BFB4 /* SecondFlowView.swift */,
+				EDB431BE2696325E0008BFB4 /* ThirdFlowView.swift */,
 			);
 			path = AddCatchu;
 			sourceTree = "<group>";
@@ -635,6 +638,7 @@
 				5B08505C26919C0B008F40B2 /* CharacterUpperView.swift in Sources */,
 				EDD12CB2268EBE4E00DF766A /* UICollectionView+Extension.swift in Sources */,
 				EDBBFCD226936F4600443077 /* CalendarCVC.swift in Sources */,
+				EDB431BF2696325E0008BFB4 /* ThirdFlowView.swift in Sources */,
 				ED63E880268A14E5000F058F /* AppDelegate.swift in Sources */,
 				EDC3780C2691D3CC007C53F2 /* ReportView.swift in Sources */,
 				EDD12CA4268EB80300DF766A /* CharacterVC.swift in Sources */,

--- a/CatchMe/CatchMe.xcodeproj/project.pbxproj
+++ b/CatchMe/CatchMe.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		ED63E882268A14E5000F058F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED63E881268A14E5000F058F /* SceneDelegate.swift */; };
 		ED63E889268A14E7000F058F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ED63E888268A14E7000F058F /* Assets.xcassets */; };
 		ED63E88C268A14E7000F058F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = ED63E88A268A14E7000F058F /* LaunchScreen.storyboard */; };
+		EDB431B226958D1F0008BFB4 /* FirstFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB431B126958D1F0008BFB4 /* FirstFlowView.swift */; };
 		EDBBFCCB26930C4600443077 /* TitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBBFCCA26930C4600443077 /* TitleView.swift */; };
 		EDBBFCCD2693155F00443077 /* CharacterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBBFCCC2693155F00443077 /* CharacterView.swift */; };
 		EDBBFCCF26934AC300443077 /* CalendarTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBBFCCE26934AC300443077 /* CalendarTitleView.swift */; };
@@ -37,6 +38,8 @@
 		EDBDC8012694481A00CDF1B2 /* PopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBDC8002694481A00CDF1B2 /* PopupView.swift */; };
 		EDBDC803269456A800CDF1B2 /* CatchuCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBDC802269456A800CDF1B2 /* CatchuCVC.swift */; };
 		EDBDC8052694B70C00CDF1B2 /* AddCatchuVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBDC8042694B70C00CDF1B2 /* AddCatchuVC.swift */; };
+		EDBDC8082695816100CDF1B2 /* AddCatchuPageControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBDC8072695816100CDF1B2 /* AddCatchuPageControl.swift */; };
+		EDBDC80A269585F800CDF1B2 /* CatchuTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBDC809269585F800CDF1B2 /* CatchuTitleView.swift */; };
 		EDC3780C2691D3CC007C53F2 /* ReportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC3780B2691D3CC007C53F2 /* ReportView.swift */; };
 		EDD12C94268EAD1F00DF766A /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD12C93268EAD1F00DF766A /* BackButton.swift */; };
 		EDD12C96268EB16800DF766A /* XmarkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDD12C95268EB16800DF766A /* XmarkButton.swift */; };
@@ -84,6 +87,7 @@
 		ED63E888268A14E7000F058F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		ED63E88B268A14E7000F058F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		ED63E88D268A14E7000F058F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		EDB431B126958D1F0008BFB4 /* FirstFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstFlowView.swift; sourceTree = "<group>"; };
 		EDBBFCCA26930C4600443077 /* TitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleView.swift; sourceTree = "<group>"; };
 		EDBBFCCC2693155F00443077 /* CharacterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterView.swift; sourceTree = "<group>"; };
 		EDBBFCCE26934AC300443077 /* CalendarTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarTitleView.swift; sourceTree = "<group>"; };
@@ -100,6 +104,8 @@
 		EDBDC8002694481A00CDF1B2 /* PopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupView.swift; sourceTree = "<group>"; };
 		EDBDC802269456A800CDF1B2 /* CatchuCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatchuCVC.swift; sourceTree = "<group>"; };
 		EDBDC8042694B70C00CDF1B2 /* AddCatchuVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCatchuVC.swift; sourceTree = "<group>"; };
+		EDBDC8072695816100CDF1B2 /* AddCatchuPageControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCatchuPageControl.swift; sourceTree = "<group>"; };
+		EDBDC809269585F800CDF1B2 /* CatchuTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatchuTitleView.swift; sourceTree = "<group>"; };
 		EDC3780B2691D3CC007C53F2 /* ReportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportView.swift; sourceTree = "<group>"; };
 		EDD12C93268EAD1F00DF766A /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
 		EDD12C95268EB16800DF766A /* XmarkButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XmarkButton.swift; sourceTree = "<group>"; };
@@ -332,6 +338,7 @@
 		ED63E89D268A1CB9000F058F /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				EDBDC8062695814100CDF1B2 /* AddCatchu */,
 				EDC3780A2691D393007C53F2 /* Report */,
 				2B3654F22691DFD3002C2C5C /* Main */,
 				5B08506E2691DFC4008F40B2 /* Character */,
@@ -367,6 +374,16 @@
 				EDBBFCD62693981C00443077 /* SpoqaHanSansNeo-Regular.otf */,
 			);
 			path = Fonts;
+			sourceTree = "<group>";
+		};
+		EDBDC8062695814100CDF1B2 /* AddCatchu */ = {
+			isa = PBXGroup;
+			children = (
+				EDBDC8072695816100CDF1B2 /* AddCatchuPageControl.swift */,
+				EDBDC809269585F800CDF1B2 /* CatchuTitleView.swift */,
+				EDB431B126958D1F0008BFB4 /* FirstFlowView.swift */,
+			);
+			path = AddCatchu;
 			sourceTree = "<group>";
 		};
 		EDC3780A2691D393007C53F2 /* Report */ = {
@@ -558,9 +575,11 @@
 				EDBDC8052694B70C00CDF1B2 /* AddCatchuVC.swift in Sources */,
 				5B0850642691A1A4008F40B2 /* CharacterHeaderView.swift in Sources */,
 				EDD12C9E268EB71000DF766A /* MainVC.swift in Sources */,
+				EDB431B226958D1F0008BFB4 /* FirstFlowView.swift in Sources */,
 				EDD12C96268EB16800DF766A /* XmarkButton.swift in Sources */,
 				EDBBFCCD2693155F00443077 /* CharacterView.swift in Sources */,
 				5B0850682691A659008F40B2 /* CharacterReportTVC.swift in Sources */,
+				EDBDC8082695816100CDF1B2 /* AddCatchuPageControl.swift in Sources */,
 				EDBBFCD4269394EE00443077 /* UIColor+Extension.swift in Sources */,
 				EDD12CAE268EBDE400DF766A /* UIScreen+Extension.swift in Sources */,
 				EDD12CAA268EBCA000DF766A /* UIView+Extension.swift in Sources */,
@@ -576,6 +595,7 @@
 				EDD12CB4268EBE6D00DF766A /* UITableView+Extension.swift in Sources */,
 				5B0850602691A126008F40B2 /* CharacterTVC.swift in Sources */,
 				EDBBFCE32693996F00443077 /* UIFont+Extension.swift in Sources */,
+				EDBDC80A269585F800CDF1B2 /* CatchuTitleView.swift in Sources */,
 				EDBDC803269456A800CDF1B2 /* CatchuCVC.swift in Sources */,
 				2B3654EB2691C4D7002C2C5C /* PageControl.swift in Sources */,
 				EDD12CA8268EB84C00DF766A /* ReportVC.swift in Sources */,

--- a/CatchMe/CatchMe.xcodeproj/project.pbxproj
+++ b/CatchMe/CatchMe.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		ED63E88C268A14E7000F058F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = ED63E88A268A14E7000F058F /* LaunchScreen.storyboard */; };
 		EDB431B226958D1F0008BFB4 /* FirstFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB431B126958D1F0008BFB4 /* FirstFlowView.swift */; };
 		EDB431B72695BA9F0008BFB4 /* CarouselCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB431B62695BA9F0008BFB4 /* CarouselCVC.swift */; };
+		EDB431BB2695F9200008BFB4 /* SecondFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB431BA2695F9200008BFB4 /* SecondFlowView.swift */; };
 		EDBBFCCB26930C4600443077 /* TitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBBFCCA26930C4600443077 /* TitleView.swift */; };
 		EDBBFCCD2693155F00443077 /* CharacterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBBFCCC2693155F00443077 /* CharacterView.swift */; };
 		EDBBFCCF26934AC300443077 /* CalendarTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBBFCCE26934AC300443077 /* CalendarTitleView.swift */; };
@@ -96,6 +97,7 @@
 		ED63E88D268A14E7000F058F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EDB431B126958D1F0008BFB4 /* FirstFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstFlowView.swift; sourceTree = "<group>"; };
 		EDB431B62695BA9F0008BFB4 /* CarouselCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselCVC.swift; sourceTree = "<group>"; };
+		EDB431BA2695F9200008BFB4 /* SecondFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondFlowView.swift; sourceTree = "<group>"; };
 		EDBBFCCA26930C4600443077 /* TitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleView.swift; sourceTree = "<group>"; };
 		EDBBFCCC2693155F00443077 /* CharacterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterView.swift; sourceTree = "<group>"; };
 		EDBBFCCE26934AC300443077 /* CalendarTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarTitleView.swift; sourceTree = "<group>"; };
@@ -418,6 +420,7 @@
 				EDBDC8072695816100CDF1B2 /* AddCatchuPageControl.swift */,
 				EDBDC809269585F800CDF1B2 /* CatchuTitleView.swift */,
 				EDB431B126958D1F0008BFB4 /* FirstFlowView.swift */,
+				EDB431BA2695F9200008BFB4 /* SecondFlowView.swift */,
 			);
 			path = AddCatchu;
 			sourceTree = "<group>";
@@ -637,6 +640,7 @@
 				EDBDC80A269585F800CDF1B2 /* CatchuTitleView.swift in Sources */,
 				EDBDC803269456A800CDF1B2 /* CatchuCVC.swift in Sources */,
 				2B3654EB2691C4D7002C2C5C /* PageControl.swift in Sources */,
+				EDB431BB2695F9200008BFB4 /* SecondFlowView.swift in Sources */,
 				EDD12CA8268EB84C00DF766A /* ReportVC.swift in Sources */,
 				EDBBFCCB26930C4600443077 /* TitleView.swift in Sources */,
 				EDD12CB0268EBE1600DF766A /* UITextField+Extension.swift in Sources */,

--- a/CatchMe/CatchMe.xcodeproj/project.pbxproj
+++ b/CatchMe/CatchMe.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		ED63E889268A14E7000F058F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ED63E888268A14E7000F058F /* Assets.xcassets */; };
 		ED63E88C268A14E7000F058F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = ED63E88A268A14E7000F058F /* LaunchScreen.storyboard */; };
 		EDB431B226958D1F0008BFB4 /* FirstFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB431B126958D1F0008BFB4 /* FirstFlowView.swift */; };
+		EDB431B72695BA9F0008BFB4 /* CarouselCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB431B62695BA9F0008BFB4 /* CarouselCVC.swift */; };
 		EDBBFCCB26930C4600443077 /* TitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBBFCCA26930C4600443077 /* TitleView.swift */; };
 		EDBBFCCD2693155F00443077 /* CharacterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBBFCCC2693155F00443077 /* CharacterView.swift */; };
 		EDBBFCCF26934AC300443077 /* CalendarTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDBBFCCE26934AC300443077 /* CalendarTitleView.swift */; };
@@ -94,6 +95,7 @@
 		ED63E88B268A14E7000F058F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		ED63E88D268A14E7000F058F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EDB431B126958D1F0008BFB4 /* FirstFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstFlowView.swift; sourceTree = "<group>"; };
+		EDB431B62695BA9F0008BFB4 /* CarouselCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselCVC.swift; sourceTree = "<group>"; };
 		EDBBFCCA26930C4600443077 /* TitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleView.swift; sourceTree = "<group>"; };
 		EDBBFCCC2693155F00443077 /* CharacterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterView.swift; sourceTree = "<group>"; };
 		EDBBFCCE26934AC300443077 /* CalendarTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarTitleView.swift; sourceTree = "<group>"; };
@@ -321,6 +323,7 @@
 		ED63E899268A1C4A000F058F /* Cells */ = {
 			isa = PBXGroup;
 			children = (
+				EDB431B52695BA800008BFB4 /* AddCatchu */,
 				2BDC1AB7269466AA008381C3 /* MainCard */,
 				EDBBFCD026936F1D00443077 /* Report */,
 				2B3654DE2691ABF6002C2C5C /* Main */,
@@ -377,6 +380,14 @@
 			children = (
 			);
 			path = APIServices;
+			sourceTree = "<group>";
+		};
+		EDB431B52695BA800008BFB4 /* AddCatchu */ = {
+			isa = PBXGroup;
+			children = (
+				EDB431B62695BA9F0008BFB4 /* CarouselCVC.swift */,
+			);
+			path = AddCatchu;
 			sourceTree = "<group>";
 		};
 		EDBBFCD026936F1D00443077 /* Report */ = {
@@ -601,6 +612,7 @@
 				EDBDC8052694B70C00CDF1B2 /* AddCatchuVC.swift in Sources */,
 				5B0850642691A1A4008F40B2 /* CharacterHeaderView.swift in Sources */,
 				EDD12C9E268EB71000DF766A /* MainVC.swift in Sources */,
+				EDB431B72695BA9F0008BFB4 /* CarouselCVC.swift in Sources */,
 				EDB431B226958D1F0008BFB4 /* FirstFlowView.swift in Sources */,
 				EDD12C96268EB16800DF766A /* XmarkButton.swift in Sources */,
 				2BDC1AB026942973008381C3 /* MainCardVC.swift in Sources */,

--- a/CatchMe/CatchMe/Resource/Info.plist
+++ b/CatchMe/CatchMe/Resource/Info.plist
@@ -43,7 +43,7 @@
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
-					<string>Report</string>
+					<string>Character</string>
 				</dict>
 			</array>
 		</dict>

--- a/CatchMe/CatchMe/Resource/Storyboards/Character.storyboard
+++ b/CatchMe/CatchMe/Resource/Storyboards/Character.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="QBA-FL-kiO">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>

--- a/CatchMe/CatchMe/Resource/Storyboards/Character.storyboard
+++ b/CatchMe/CatchMe/Resource/Storyboards/Character.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="QBA-FL-kiO">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>

--- a/CatchMe/CatchMe/Source/Cells/AddCatchu/CarouselCVC.swift
+++ b/CatchMe/CatchMe/Source/Cells/AddCatchu/CarouselCVC.swift
@@ -1,0 +1,27 @@
+//
+//  CarouselCVC.swift
+//  CatchMe
+//
+//  Created by SHIN YOON AH on 2021/07/07.
+//
+
+import UIKit
+
+class CarouselCVC: UICollectionViewCell {
+    static let identifier = "CarouselCVC"
+    
+    // MARK: - Life Cycle
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Custom Methods
+    /// asset 넣기 전까지 dummy Color
+    func setupCharacter(color: UIColor) {
+        backgroundColor = color
+    }
+}

--- a/CatchMe/CatchMe/Source/Cells/AddCatchu/CarouselCVC.swift
+++ b/CatchMe/CatchMe/Source/Cells/AddCatchu/CarouselCVC.swift
@@ -19,7 +19,7 @@ class CarouselCVC: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    // MARK: - Custom Methods
+    // MARK: - Custom Method
     /// asset 넣기 전까지 dummy Color
     func setupCharacter(color: UIColor) {
         backgroundColor = color

--- a/CatchMe/CatchMe/Source/Components/AddCatchu/AddCatchuPageControl.swift
+++ b/CatchMe/CatchMe/Source/Components/AddCatchu/AddCatchuPageControl.swift
@@ -8,11 +8,13 @@
 import UIKit
 
 class AddCatchuPageControl: UIView {
+    // MARK: - Properties
     var pages: Int = 0 {
         didSet {
             setNeedsDisplay()
         }
     }
+    
     var selectedPage: Int = 0 {
         didSet {
             setNeedsDisplay()
@@ -34,6 +36,8 @@ class AddCatchuPageControl: UIView {
     private let dotSize: CGFloat = 6
     private let spacing: CGFloat = 6
     
+    
+    // MARK: - Life Cycle
     init() {
         super.init(frame: .zero)
         isOpaque = false
@@ -43,6 +47,7 @@ class AddCatchuPageControl: UIView {
         fatalError("Unsupported")
     }
     
+    // MARK: - draw
     override func draw(_ rect: CGRect) {
         (0..<pages).forEach { page in
             (page == selectedPage ? selectedColor : dotColor).setFill()

--- a/CatchMe/CatchMe/Source/Components/AddCatchu/AddCatchuPageControl.swift
+++ b/CatchMe/CatchMe/Source/Components/AddCatchu/AddCatchuPageControl.swift
@@ -1,0 +1,55 @@
+//
+//  AddCatchuPageControl.swift
+//  CatchMe
+//
+//  Created by SHIN YOON AH on 2021/07/07.
+//
+
+import UIKit
+
+class AddCatchuPageControl: UIView {
+    var pages: Int = 0 {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    var selectedPage: Int = 0 {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    
+    var dotColor = UIColor.lightGray {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    
+    var selectedColor = UIColor.init(red: 234/255, green: 69/255, blue: 121/255, alpha: 1.0) {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    
+    private let dotSize: CGFloat = 6
+    private let spacing: CGFloat = 6
+    
+    init() {
+        super.init(frame: .zero)
+        isOpaque = false
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("Unsupported")
+    }
+    
+    override func draw(_ rect: CGRect) {
+        (0..<pages).forEach { page in
+            (page == selectedPage ? selectedColor : dotColor).setFill()
+            let center = CGPoint(x: rect.minX + dotSize / 2 + (dotSize + spacing) * CGFloat(page), y: rect.midY)
+            let size = CGSize(width: 6, height: 6)
+            let rect = CGRect(origin: center, size: size)
+            UIBezierPath(roundedRect: rect, cornerRadius: 3).fill()
+        }
+    }
+}

--- a/CatchMe/CatchMe/Source/Components/AddCatchu/CatchuTitleView.swift
+++ b/CatchMe/CatchMe/Source/Components/AddCatchu/CatchuTitleView.swift
@@ -43,7 +43,7 @@ class CatchuTitleView: UIView {
         }
     }
     
-    // MARK: - Custom Methods
+    // MARK: - Custom Method
     private func configUI(title: String, subTitle: String) {
         addSubviews([titleLabel, subTitleLabel])
         

--- a/CatchMe/CatchMe/Source/Components/AddCatchu/CatchuTitleView.swift
+++ b/CatchMe/CatchMe/Source/Components/AddCatchu/CatchuTitleView.swift
@@ -1,0 +1,56 @@
+//
+//  CatchuTitleView.swift
+//  CatchMe
+//
+//  Created by SHIN YOON AH on 2021/07/07.
+//
+
+import UIKit
+
+import Then
+import SnapKit
+
+class CatchuTitleView: UIView {
+    // MARK: - Properties
+    let titleLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 22, weight: .medium)
+        $0.textColor = .white
+    }
+    
+    let subTitleLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 14, weight: .medium)
+        $0.textColor = .white
+    }
+    
+    // MARK: - Life Cycle
+    init(title: String, subTitle: String) {
+        super.init(frame: .zero)
+        configUI(title: title, subTitle: subTitle)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+        titleLabel.snp.makeConstraints { make in
+            make.top.leading.equalToSuperview()
+        }
+        
+        subTitleLabel.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(10)
+            make.leading.equalTo(titleLabel.snp.leading)
+        }
+    }
+    
+    // MARK: - Custom Methods
+    private func configUI(title: String, subTitle: String) {
+        addSubviews([titleLabel, subTitleLabel])
+        
+        let attributedStr = NSMutableAttributedString(string: title)
+        attributedStr.addAttribute(.foregroundColor, value: UIColor.systemPink, range: (title as NSString).range(of: "캐츄"))
+        titleLabel.attributedText = attributedStr
+        
+        subTitleLabel.text = subTitle
+    }
+}

--- a/CatchMe/CatchMe/Source/Components/AddCatchu/FirstFlowView.swift
+++ b/CatchMe/CatchMe/Source/Components/AddCatchu/FirstFlowView.swift
@@ -10,28 +10,152 @@ import UIKit
 import SnapKit
 
 class FirstFlowView: UIView {
+    // MARK: - Lazy Properties
+    lazy var catchuCollectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowLayout)
+    lazy var cellCount = colors.count
+    
     // MARK: - Properties
     let titleView = CatchuTitleView(title: "새로운 캐츄를 잡아볼까요?", subTitle: "내 모습을 가장 잘 보여주는 캐츄를 골라주세요")
+    let collectionViewFlowLayout = UICollectionViewFlowLayout()
+    let cellSize = CGSize(width: 150, height: 150)
+    var minItemSpacing: CGFloat = 25
+    var previousIndex = 0
+    
+    // MARK: - Dummy Data
+    /// 후에 enum으로 사용하면 편리할 듯 -> 아니면 public하게 전체적으로 사용할 수 있도록 만들기
+    let colors: [UIColor] = [.systemRed, .systemBlue, .systemPink, .systemTeal, .systemGray, .systemGreen, .systemOrange, .systemYellow, .systemPurple, .systemIndigo]
 
     // MARK: - Life Cycle
     override init(frame: CGRect) {
         super.init(frame: frame)
-        configUI()
+        setupLayout()
+        setupCollectionView()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func layoutSubviews() {
+    // MARK: - Custom Methods
+    private func setupLayout() {
+        addSubviews([titleView, catchuCollectionView])
+        
         titleView.snp.makeConstraints { make in
             make.top.equalToSuperview()
             make.leading.equalToSuperview().inset(28)
         }
+        
+        catchuCollectionView.snp.makeConstraints { make in
+            make.top.equalTo(titleView.snp.bottom).offset(UIScreen.main.hasNotch ? 160 : 100)
+            make.trailing.leading.equalToSuperview()
+            make.height.equalTo(250)
+        }
     }
     
-    // MARK: - Custom Methods
-    private func configUI() {
-        addSubviews([titleView])
+    private func setupCollectionView() {
+        collectionViewFlowLayout.scrollDirection = .horizontal
+        
+        catchuCollectionView.dataSource = self
+        catchuCollectionView.delegate = self
+        catchuCollectionView.register(CarouselCVC.self, forCellWithReuseIdentifier: CarouselCVC.identifier)
+        
+        catchuCollectionView.backgroundColor = .clear
+        catchuCollectionView.contentInsetAdjustmentBehavior = .never
+        let cellWidth: CGFloat = floor(cellSize.width)
+        let insetX = (UIScreen.main.bounds.size.width - cellWidth) / 2.0
+        catchuCollectionView.contentInset = UIEdgeInsets(top: 0, left: insetX, bottom: 0, right: insetX)
+        catchuCollectionView.decelerationRate = .fast
+        catchuCollectionView.contentInsetAdjustmentBehavior = .never
+        catchuCollectionView.showsHorizontalScrollIndicator = false
+        
+        DispatchQueue.main.asyncAfter(deadline: .now()+0.01, execute: {
+            let indexPath = IndexPath(item: 0, section: 0)
+            if let cell = self.catchuCollectionView.cellForItem(at: indexPath) {
+                self.animateZoomforCell(zoomCell: cell)
+            }
+        })
+    }
+}
+
+// MARK: - UICollectionViewDataSource
+extension FirstFlowView: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return colors.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CarouselCVC.identifier, for: indexPath) as? CarouselCVC else {
+            return UICollectionViewCell()
+        }
+        cell.setupCharacter(color: colors[indexPath.item])
+        animateZoomforCellremove(zoomCell: cell)
+        return cell
+    }
+}
+
+// MARK: - UICollectionViewDelegateFlowLayout
+extension FirstFlowView: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return minItemSpacing
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return cellSize
+    }
+}
+
+// MARK: - UICollectionViewDelegate
+extension FirstFlowView: UICollectionViewDelegate {
+    /// paging effect
+    func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        let cellWidthIncludeSpacing = cellSize.width + minItemSpacing
+        
+        var offset = targetContentOffset.pointee
+        let index = (offset.x + scrollView.contentInset.left) / cellWidthIncludeSpacing
+        let roundedIndex: CGFloat = round(index)
+        
+        offset = CGPoint(x: roundedIndex * cellWidthIncludeSpacing - scrollView.contentInset.left, y: scrollView.contentInset.top)
+        targetContentOffset.pointee = offset
+    }
+    
+    /// Carousel Effect
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let cellWidthIncludeSpacing = cellSize.width + minItemSpacing
+        let offsetX = catchuCollectionView.contentOffset.x
+        let index = (offsetX + catchuCollectionView.contentInset.left) / cellWidthIncludeSpacing
+        let roundedIndex = round(index)
+        let indexPath = IndexPath(item: Int(roundedIndex), section: 0)
+        if let cell = catchuCollectionView.cellForItem(at: indexPath) {
+            animateZoomforCell(zoomCell: cell)
+        }
+        
+        if Int(roundedIndex) != previousIndex {
+            let preIndexPath = IndexPath(item: previousIndex, section: 0)
+            if let preCell = catchuCollectionView.cellForItem(at: preIndexPath) {
+                animateZoomforCellremove(zoomCell: preCell)
+            }
+            previousIndex = indexPath.item
+        }
+    }
+    
+    func animateZoomforCell(zoomCell: UICollectionViewCell) {
+       let anim = CATransform3DTranslate(CATransform3DIdentity, 0, -35, 0.5)
+       UIView.animate(
+           withDuration: 0.2,
+           delay: 0,
+           options: .curveEaseOut,
+           animations: {
+               zoomCell.transform3D = anim
+       }, completion: nil)
+    }
+   
+    func animateZoomforCellremove(zoomCell: UICollectionViewCell) {
+       UIView.animate(
+           withDuration: 0.2,
+           delay: 0,
+           options: .curveEaseOut,
+           animations: {
+               zoomCell.transform3D = CATransform3DScale(CATransform3DIdentity, 0.5, 0.5, 1)
+       }, completion: nil)
     }
 }

--- a/CatchMe/CatchMe/Source/Components/AddCatchu/FirstFlowView.swift
+++ b/CatchMe/CatchMe/Source/Components/AddCatchu/FirstFlowView.swift
@@ -10,6 +10,7 @@ import UIKit
 import SnapKit
 
 class FirstFlowView: UIView {
+    // MARK: - Properties
     let titleView = CatchuTitleView(title: "새로운 캐츄를 잡아볼까요?", subTitle: "내 모습을 가장 잘 보여주는 캐츄를 골라주세요")
 
     // MARK: - Life Cycle

--- a/CatchMe/CatchMe/Source/Components/AddCatchu/FirstFlowView.swift
+++ b/CatchMe/CatchMe/Source/Components/AddCatchu/FirstFlowView.swift
@@ -1,0 +1,36 @@
+//
+//  FirstFlowView.swift
+//  CatchMe
+//
+//  Created by SHIN YOON AH on 2021/07/07.
+//
+
+import UIKit
+
+import SnapKit
+
+class FirstFlowView: UIView {
+    let titleView = CatchuTitleView(title: "새로운 캐츄를 잡아볼까요?", subTitle: "내 모습을 가장 잘 보여주는 캐츄를 골라주세요")
+
+    // MARK: - Life Cycle
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+        titleView.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.leading.equalToSuperview().inset(28)
+        }
+    }
+    
+    // MARK: - Custom Methods
+    private func configUI() {
+        addSubviews([titleView])
+    }
+}

--- a/CatchMe/CatchMe/Source/Components/AddCatchu/FirstFlowView.swift
+++ b/CatchMe/CatchMe/Source/Components/AddCatchu/FirstFlowView.swift
@@ -18,6 +18,7 @@ class FirstFlowView: UIView {
     let titleView = CatchuTitleView(title: "새로운 캐츄를 잡아볼까요?", subTitle: "내 모습을 가장 잘 보여주는 캐츄를 골라주세요")
     let collectionViewFlowLayout = UICollectionViewFlowLayout()
     let cellSize = CGSize(width: 150, height: 150)
+    
     var minItemSpacing: CGFloat = 25
     var previousIndex = 0
     
@@ -61,12 +62,13 @@ class FirstFlowView: UIView {
         
         catchuCollectionView.backgroundColor = .clear
         catchuCollectionView.contentInsetAdjustmentBehavior = .never
-        let cellWidth: CGFloat = floor(cellSize.width)
-        let insetX = (UIScreen.main.bounds.size.width - cellWidth) / 2.0
-        catchuCollectionView.contentInset = UIEdgeInsets(top: 0, left: insetX, bottom: 0, right: insetX)
         catchuCollectionView.decelerationRate = .fast
         catchuCollectionView.contentInsetAdjustmentBehavior = .never
         catchuCollectionView.showsHorizontalScrollIndicator = false
+        
+        let cellWidth: CGFloat = floor(cellSize.width)
+        let insetX = (UIScreen.main.bounds.size.width - cellWidth) / 2.0
+        catchuCollectionView.contentInset = UIEdgeInsets(top: 0, left: insetX, bottom: 0, right: insetX)
         
         DispatchQueue.main.asyncAfter(deadline: .now()+0.01, execute: {
             let indexPath = IndexPath(item: 0, section: 0)
@@ -95,12 +97,12 @@ extension FirstFlowView: UICollectionViewDataSource {
 
 // MARK: - UICollectionViewDelegateFlowLayout
 extension FirstFlowView: UICollectionViewDelegateFlowLayout {
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        return minItemSpacing
-    }
-    
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return cellSize
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return minItemSpacing
     }
 }
 
@@ -109,7 +111,6 @@ extension FirstFlowView: UICollectionViewDelegate {
     /// paging effect
     func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
         let cellWidthIncludeSpacing = cellSize.width + minItemSpacing
-        
         var offset = targetContentOffset.pointee
         let index = (offset.x + scrollView.contentInset.left) / cellWidthIncludeSpacing
         let roundedIndex: CGFloat = round(index)
@@ -138,24 +139,22 @@ extension FirstFlowView: UICollectionViewDelegate {
         }
     }
     
-    func animateZoomforCell(zoomCell: UICollectionViewCell) {
-       let anim = CATransform3DTranslate(CATransform3DIdentity, 0, -35, 0.5)
-       UIView.animate(
-           withDuration: 0.2,
-           delay: 0,
-           options: .curveEaseOut,
-           animations: {
-               zoomCell.transform3D = anim
-       }, completion: nil)
+    private func animateZoomforCell(zoomCell: UICollectionViewCell) {
+       let animation = CATransform3DTranslate(CATransform3DIdentity, 0, -35, 0.5)
+       UIView.animate(withDuration: 0.2,
+                      delay: 0,
+                      options: .curveEaseOut,
+                      animations: {
+                        zoomCell.transform3D = animation
+                      }, completion: nil)
     }
    
-    func animateZoomforCellremove(zoomCell: UICollectionViewCell) {
-       UIView.animate(
-           withDuration: 0.2,
-           delay: 0,
-           options: .curveEaseOut,
-           animations: {
-               zoomCell.transform3D = CATransform3DScale(CATransform3DIdentity, 0.5, 0.5, 1)
-       }, completion: nil)
+    private func animateZoomforCellremove(zoomCell: UICollectionViewCell) {
+       UIView.animate(withDuration: 0.2,
+                      delay: 0,
+                      options: .curveEaseOut,
+                      animations: {
+                        zoomCell.transform3D = CATransform3DScale(CATransform3DIdentity, 0.5, 0.5, 1)
+                      }, completion: nil)
     }
 }

--- a/CatchMe/CatchMe/Source/Components/AddCatchu/SecondFlowView.swift
+++ b/CatchMe/CatchMe/Source/Components/AddCatchu/SecondFlowView.swift
@@ -1,0 +1,56 @@
+//
+//  SecondFlowView.swift
+//  CatchMe
+//
+//  Created by SHIN YOON AH on 2021/07/08.
+//
+
+import UIKit
+
+import Then
+import SnapKit
+
+class SecondFlowView: UIView {
+    // MARK: - Properties
+    let titleView = CatchuTitleView(title: "하나뿐인 내 캐츄의 이름은?", subTitle: "나의 캐츄를 대표할 이름을 지어주세요")
+    let characterImageView = UIImageView(image: UIImage(named: ""))
+    
+    // MARK: - Dummy Data
+    /// 후에 enum으로 사용하면 편리할 듯 -> 아니면 public하게 전체적으로 사용할 수 있도록 만들기
+    let colors: [UIColor] = [.systemRed, .systemBlue, .systemPink, .systemTeal, .systemGray, .systemGreen, .systemOrange, .systemYellow, .systemPurple, .systemIndigo]
+
+    // MARK: - Life Cycle
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+        configUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Custom Methods
+    private func setupLayout() {
+        addSubviews([titleView, characterImageView])
+        
+        titleView.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.leading.equalToSuperview().inset(28)
+        }
+        
+        characterImageView.snp.makeConstraints { make in
+            make.top.equalTo(titleView.snp.bottom).offset(UIScreen.main.hasNotch ? 175 : 115)
+            make.centerX.equalToSuperview()
+            make.height.width.equalTo(150)
+        }
+    }
+    
+    private func configUI() {
+        
+    }
+    
+    func setImageViewColor(selectedIndex: Int) {
+        characterImageView.backgroundColor = colors[selectedIndex]
+    }
+}

--- a/CatchMe/CatchMe/Source/Components/AddCatchu/SecondFlowView.swift
+++ b/CatchMe/CatchMe/Source/Components/AddCatchu/SecondFlowView.swift
@@ -14,10 +14,16 @@ class SecondFlowView: UIView {
     let titleView = CatchuTitleView(title: "하나뿐인 내 캐츄의 이름은?", subTitle: "나의 캐츄를 대표할 이름을 지어주세요")
     let characterImageView = UIImageView(image: UIImage(named: ""))
     let textField = CustomTextField(placeholder: "캐츄 이름 입력")
+    let recommendLabel = UILabel()
+    let countLabel = UILabel()
+    
+    var textCount = 0
     
     // MARK: - Dummy Data
     /// 후에 enum으로 사용하면 편리할 듯 -> 아니면 public하게 전체적으로 사용할 수 있도록 만들기
     let colors: [UIColor] = [.systemRed, .systemBlue, .systemPink, .systemTeal, .systemGray, .systemGreen, .systemOrange, .systemYellow, .systemPurple, .systemIndigo]
+    let recommends: [String] = ["‘___없이 못사는 ___러버’", "‘___랑 함께사는 ___집사’", "‘___만 먹는 ___중독자’", "‘___를 하루종일 하는 ___러버’", "‘___이 너무 재밌는 ___처돌이’", "‘당장 ___하고픈 ___중독자’"]
+    var randomIndex = Int.random(in: 0...5)
 
     // MARK: - Life Cycle
     override init(frame: CGRect) {
@@ -32,7 +38,8 @@ class SecondFlowView: UIView {
     
     // MARK: - Custom Methods
     private func setupLayout() {
-        addSubviews([titleView, characterImageView, textField])
+        addSubviews([titleView, characterImageView,
+                     textField, recommendLabel, countLabel])
         
         titleView.snp.makeConstraints { make in
             make.top.equalToSuperview()
@@ -46,16 +53,90 @@ class SecondFlowView: UIView {
         }
         
         textField.snp.makeConstraints { make in
-            make.top.equalTo(characterImageView.snp.bottom).offset(74)
+            make.top.equalTo(characterImageView.snp.bottom).offset(UIScreen.main.hasNotch ? 74 : 40)
             make.leading.trailing.equalToSuperview().inset(28)
+        }
+        
+        recommendLabel.snp.makeConstraints { make in
+            make.top.equalTo(textField.snp.bottom).offset(8)
+            make.leading.equalToSuperview().inset(45)
+        }
+        
+        countLabel.snp.makeConstraints { make in
+            make.top.equalTo(textField.snp.bottom).offset(4)
+            make.trailing.equalToSuperview().inset(28)
         }
     }
     
     private func configUI() {
+        textField.delegate = self
+        textField.addTarget(self, action: #selector(textDidChanged(_:)), for: .editingChanged)
         
+        recommendLabel.font = .systemFont(ofSize: 12)
+        recommendLabel.textColor = .gray400
+        recommendLabel.text = "캐치미 추천: " + recommends[randomIndex]
+        
+        countLabel.textAlignment = .right
+        countLabel.isHidden = true
+        countLabel.textColor = .gray200
+        countLabel.font = .systemFont(ofSize: 14)
+        countLabel.text = "\(textCount)/20"
     }
     
     func setImageViewColor(selectedIndex: Int) {
         characterImageView.backgroundColor = colors[selectedIndex]
+    }
+}
+
+// MARK: - UITextFieldDelegate
+extension SecondFlowView: UITextFieldDelegate {
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        textField.becomeFirstResponder()
+        
+        self.textField.setupPinkLine()
+        
+        UIView.animate(withDuration: 0.2, animations: {
+            self.characterImageView.transform = CGAffineTransform(translationX: 0, y: UIScreen.main.hasNotch ? -74 : -50)
+            textField.transform = CGAffineTransform(translationX: 0, y: UIScreen.main.hasNotch ? -122 : -65)
+            self.countLabel.transform = CGAffineTransform(translationX: 0, y: UIScreen.main.hasNotch ? -122 : -65)
+        })
+        
+        recommendLabel.isHidden = true
+        countLabel.isHidden = false
+    }
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        self.textField.setupOriginalLine()
+        if !textField.hasText {
+            recommendLabel.isHidden = false
+            countLabel.isHidden = true
+        }
+    }
+    
+    @objc
+    func textDidChanged(_ sender: Any) {
+        textCount = textField.text?.count ?? 0
+        
+        switch textCount {
+        case 0:
+            countLabel.text = "0/20"
+            countLabel.textColor = .gray200
+        case 20:
+            let attributedStr = NSMutableAttributedString(string: "20/20")
+            attributedStr.addAttribute(.foregroundColor, value: UIColor.systemPink, range: ("20/20" as NSString).range(of: "20/20"))
+            countLabel.attributedText = attributedStr
+        default:
+            let attributedStr = NSMutableAttributedString(string: "\(textCount)/20")
+            attributedStr.addAttribute(.foregroundColor, value: UIColor.systemPink, range: ("\(textCount)/20" as NSString).range(of: "\(textCount)"))
+            countLabel.attributedText = attributedStr
+        }
+        
+        checkMaxLength(textField: textField, maxLength: 20)
+    }
+    
+    func checkMaxLength(textField: UITextField!, maxLength: Int) {
+        if (textField.text?.count ?? 0 > maxLength) {
+            textField.deleteBackward()
+        }
     }
 }

--- a/CatchMe/CatchMe/Source/Components/AddCatchu/SecondFlowView.swift
+++ b/CatchMe/CatchMe/Source/Components/AddCatchu/SecondFlowView.swift
@@ -12,18 +12,18 @@ import SnapKit
 class SecondFlowView: UIView {
     // MARK: - Properties
     let titleView = CatchuTitleView(title: "하나뿐인 내 캐츄의 이름은?", subTitle: "나의 캐츄를 대표할 이름을 지어주세요")
-    let characterImageView = UIImageView(image: UIImage(named: ""))
+    let characterImageView = UIImageView()
     let textField = CustomTextField(placeholder: "캐츄 이름 입력")
     let recommendLabel = UILabel()
     let countLabel = UILabel()
     
     var textCount = 0
+    var randomIndex = Int.random(in: 0...5)
+    let recommends: [String] = ["‘___없이 못사는 ___러버’", "‘___랑 함께사는 ___집사’", "‘___만 먹는 ___중독자’", "‘___를 하루종일 하는 ___러버’", "‘___이 너무 재밌는 ___처돌이’", "‘당장 ___하고픈 ___중독자’"]
     
     // MARK: - Dummy Data
     /// 후에 enum으로 사용하면 편리할 듯 -> 아니면 public하게 전체적으로 사용할 수 있도록 만들기
     let colors: [UIColor] = [.systemRed, .systemBlue, .systemPink, .systemTeal, .systemGray, .systemGreen, .systemOrange, .systemYellow, .systemPurple, .systemIndigo]
-    let recommends: [String] = ["‘___없이 못사는 ___러버’", "‘___랑 함께사는 ___집사’", "‘___만 먹는 ___중독자’", "‘___를 하루종일 하는 ___러버’", "‘___이 너무 재밌는 ___처돌이’", "‘당장 ___하고픈 ___중독자’"]
-    var randomIndex = Int.random(in: 0...5)
 
     // MARK: - Life Cycle
     override init(frame: CGRect) {
@@ -83,6 +83,8 @@ class SecondFlowView: UIView {
         countLabel.text = "\(textCount)/20"
     }
     
+    // MARK: - external use function
+    /// asset 넣기 전까지 dummy Color
     func setImageViewColor(selectedIndex: Int) {
         characterImageView.backgroundColor = colors[selectedIndex]
     }
@@ -92,21 +94,21 @@ class SecondFlowView: UIView {
 extension SecondFlowView: UITextFieldDelegate {
     func textFieldDidBeginEditing(_ textField: UITextField) {
         textField.becomeFirstResponder()
-        
         self.textField.setupPinkLine()
+        
+        recommendLabel.isHidden = true
+        countLabel.isHidden = false
         
         UIView.animate(withDuration: 0.2, animations: {
             self.characterImageView.transform = CGAffineTransform(translationX: 0, y: UIScreen.main.hasNotch ? -74 : -50)
             textField.transform = CGAffineTransform(translationX: 0, y: UIScreen.main.hasNotch ? -122 : -65)
             self.countLabel.transform = CGAffineTransform(translationX: 0, y: UIScreen.main.hasNotch ? -122 : -65)
         })
-        
-        recommendLabel.isHidden = true
-        countLabel.isHidden = false
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
         self.textField.setupOriginalLine()
+        
         if !textField.hasText {
             recommendLabel.isHidden = false
             countLabel.isHidden = true

--- a/CatchMe/CatchMe/Source/Components/AddCatchu/SecondFlowView.swift
+++ b/CatchMe/CatchMe/Source/Components/AddCatchu/SecondFlowView.swift
@@ -7,13 +7,13 @@
 
 import UIKit
 
-import Then
 import SnapKit
 
 class SecondFlowView: UIView {
     // MARK: - Properties
     let titleView = CatchuTitleView(title: "하나뿐인 내 캐츄의 이름은?", subTitle: "나의 캐츄를 대표할 이름을 지어주세요")
     let characterImageView = UIImageView(image: UIImage(named: ""))
+    let textField = CustomTextField(placeholder: "캐츄 이름 입력")
     
     // MARK: - Dummy Data
     /// 후에 enum으로 사용하면 편리할 듯 -> 아니면 public하게 전체적으로 사용할 수 있도록 만들기
@@ -32,7 +32,7 @@ class SecondFlowView: UIView {
     
     // MARK: - Custom Methods
     private func setupLayout() {
-        addSubviews([titleView, characterImageView])
+        addSubviews([titleView, characterImageView, textField])
         
         titleView.snp.makeConstraints { make in
             make.top.equalToSuperview()
@@ -43,6 +43,11 @@ class SecondFlowView: UIView {
             make.top.equalTo(titleView.snp.bottom).offset(UIScreen.main.hasNotch ? 175 : 115)
             make.centerX.equalToSuperview()
             make.height.width.equalTo(150)
+        }
+        
+        textField.snp.makeConstraints { make in
+            make.top.equalTo(characterImageView.snp.bottom).offset(74)
+            make.leading.trailing.equalToSuperview().inset(28)
         }
     }
     

--- a/CatchMe/CatchMe/Source/Components/AddCatchu/ThirdFlowView.swift
+++ b/CatchMe/CatchMe/Source/Components/AddCatchu/ThirdFlowView.swift
@@ -12,8 +12,8 @@ import SnapKit
 class ThirdFlowView: UIView {
     // MARK: - Properties
     let titleView = CatchuTitleView(title: "새로운 캐츄가 태어났어요!", subTitle: "내 안에 방금 생겨난 캐츄를 확인하세요")
-    let characterImageView = UIImageView(image: UIImage(named: ""))
-    let backgroundImageView = UIImageView(image: UIImage(named: ""))
+    let characterImageView = UIImageView()
+    let backgroundImageView = UIImageView()
     let nameLabel = UILabel()
     let lockLabel = UILabel()
     let lockButton = UIButton()
@@ -101,6 +101,8 @@ class ThirdFlowView: UIView {
         lockButton.addAction(lockAction, for: .touchUpInside)
     }
     
+    // MARK: - external use function
+    /// asset 넣기 전까지 dummy Color
     func setImageViewColor(selectedIndex: Int) {
         characterImageView.backgroundColor = colors[selectedIndex]
     }

--- a/CatchMe/CatchMe/Source/Components/AddCatchu/ThirdFlowView.swift
+++ b/CatchMe/CatchMe/Source/Components/AddCatchu/ThirdFlowView.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import SnapKit
+
 class ThirdFlowView: UIView {
     // MARK: - Properties
     let titleView = CatchuTitleView(title: "새로운 캐츄가 태어났어요!", subTitle: "내 안에 방금 생겨난 캐츄를 확인하세요")
@@ -17,6 +19,7 @@ class ThirdFlowView: UIView {
     let lockButton = UIButton()
     
     var textCount = 0
+    var isLock = false
     
     // MARK: - Dummy Data
     /// 후에 enum으로 사용하면 편리할 듯 -> 아니면 public하게 전체적으로 사용할 수 있도록 만들기
@@ -27,6 +30,7 @@ class ThirdFlowView: UIView {
         super.init(frame: frame)
         setupLayout()
         configUI()
+        setupButtonAction()
     }
     
     required init?(coder: NSCoder) {
@@ -35,7 +39,7 @@ class ThirdFlowView: UIView {
     
     // MARK: - Custom Methods
     private func setupLayout() {
-        addSubviews([titleView, characterImageView, backgroundImageView,
+        addSubviews([titleView, backgroundImageView, characterImageView,
                      nameLabel, lockLabel, lockButton])
         
         titleView.snp.makeConstraints { make in
@@ -48,13 +52,60 @@ class ThirdFlowView: UIView {
             make.centerX.equalToSuperview()
             make.height.width.equalTo(150)
         }
+        
+        backgroundImageView.snp.makeConstraints { make in
+            make.bottom.equalTo(characterImageView.snp.bottom).offset(1)
+            make.centerX.equalToSuperview()
+            make.height.width.equalTo(181)
+        }
+        
+        nameLabel.snp.makeConstraints { make in
+            make.top.equalTo(characterImageView.snp.bottom).offset(39)
+            make.centerX.equalToSuperview()
+            make.width.equalTo(190)
+        }
+        
+        lockButton.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(22)
+            make.bottom.equalToSuperview().inset(14)
+            make.width.height.equalTo(34)
+        }
+        
+        lockLabel.snp.makeConstraints { make in
+            make.leading.equalTo(lockButton.snp.trailing).offset(8)
+            make.centerY.equalTo(lockButton.snp.centerY)
+        }
     }
     
     private func configUI() {
+        backgroundImageView.backgroundColor = .white
         
+        nameLabel.numberOfLines = 2
+        nameLabel.lineBreakMode = .byWordWrapping
+        nameLabel.textColor = .white
+        nameLabel.textAlignment = .center
+        nameLabel.font = .systemFont(ofSize: 22, weight: .black)
+        
+        lockButton.backgroundColor = .systemPink
+        
+        lockLabel.text = "다른 사용자에게 공개할래요"
+        lockLabel.font = .systemFont(ofSize: 14)
+        lockLabel.textColor = .white
+    }
+    
+    private func setupButtonAction() {
+        let lockAction = UIAction { _ in
+            self.lockButton.backgroundColor = self.isLock ? .systemPink : .gray
+            self.isLock.toggle()
+        }
+        lockButton.addAction(lockAction, for: .touchUpInside)
     }
     
     func setImageViewColor(selectedIndex: Int) {
         characterImageView.backgroundColor = colors[selectedIndex]
+    }
+    
+    func setCharacterName(name: String) {
+        nameLabel.text = name
     }
 }

--- a/CatchMe/CatchMe/Source/Components/AddCatchu/ThirdFlowView.swift
+++ b/CatchMe/CatchMe/Source/Components/AddCatchu/ThirdFlowView.swift
@@ -1,0 +1,60 @@
+//
+//  ThirdFlowView.swift
+//  CatchMe
+//
+//  Created by SHIN YOON AH on 2021/07/08.
+//
+
+import UIKit
+
+class ThirdFlowView: UIView {
+    // MARK: - Properties
+    let titleView = CatchuTitleView(title: "새로운 캐츄가 태어났어요!", subTitle: "내 안에 방금 생겨난 캐츄를 확인하세요")
+    let characterImageView = UIImageView(image: UIImage(named: ""))
+    let backgroundImageView = UIImageView(image: UIImage(named: ""))
+    let nameLabel = UILabel()
+    let lockLabel = UILabel()
+    let lockButton = UIButton()
+    
+    var textCount = 0
+    
+    // MARK: - Dummy Data
+    /// 후에 enum으로 사용하면 편리할 듯 -> 아니면 public하게 전체적으로 사용할 수 있도록 만들기
+    let colors: [UIColor] = [.systemRed, .systemBlue, .systemPink, .systemTeal, .systemGray, .systemGreen, .systemOrange, .systemYellow, .systemPurple, .systemIndigo]
+
+    // MARK: - Life Cycle
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+        configUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Custom Methods
+    private func setupLayout() {
+        addSubviews([titleView, characterImageView, backgroundImageView,
+                     nameLabel, lockLabel, lockButton])
+        
+        titleView.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.leading.equalToSuperview().inset(28)
+        }
+        
+        characterImageView.snp.makeConstraints { make in
+            make.top.equalTo(titleView.snp.bottom).offset(UIScreen.main.hasNotch ? 175 : 115)
+            make.centerX.equalToSuperview()
+            make.height.width.equalTo(150)
+        }
+    }
+    
+    private func configUI() {
+        
+    }
+    
+    func setImageViewColor(selectedIndex: Int) {
+        characterImageView.backgroundColor = colors[selectedIndex]
+    }
+}

--- a/CatchMe/CatchMe/Source/Components/Shared/BackButton.swift
+++ b/CatchMe/CatchMe/Source/Components/Shared/BackButton.swift
@@ -8,6 +8,12 @@
 import UIKit
 
 class BackButton: UIButton {
+    
+    init() {
+        super.init(frame: .zero)
+        configUI()
+        setupLayout()
+    }
 
     init(_ vc: UIViewController) {
         super.init(frame: .zero)

--- a/CatchMe/CatchMe/Source/Components/Shared/BottomButton.swift
+++ b/CatchMe/CatchMe/Source/Components/Shared/BottomButton.swift
@@ -7,10 +7,13 @@
 
 import UIKit
 
+import SnapKit
+
 class BottomButton: UIButton {
 
     init(title: String) {
         super.init(frame: .zero)
+        setupLayout()
         configUI(title: title)
     }
     
@@ -19,11 +22,18 @@ class BottomButton: UIButton {
     }
     
     // MARK: - Extension Color, Font들어오면 바꿀 예정
+    private func setupLayout() {
+        self.snp.makeConstraints { make in
+            make.height.equalTo(54)
+        }
+    }
+    
     private func configUI(title: String) {
         backgroundColor = .systemPink
         setTitle(title, for: .normal)
         setTitleColor(.white, for: .normal)
-        titleLabel?.font = .boldSystemFont(ofSize: 18)
+        titleLabel?.font = .systemFont(ofSize: 16, weight: .medium)
+        layer.cornerRadius = 25
     }
     
     // MARK: - BottomButton Action

--- a/CatchMe/CatchMe/Source/Components/Shared/BottomButton.swift
+++ b/CatchMe/CatchMe/Source/Components/Shared/BottomButton.swift
@@ -37,4 +37,7 @@ class BottomButton: UIButton {
     }
     
     // MARK: - BottomButton Action
+    func changeBottomButtonTitle(title: String) {
+        setTitle(title, for: .normal)
+    }
 }

--- a/CatchMe/CatchMe/Source/Components/Shared/BottomButton.swift
+++ b/CatchMe/CatchMe/Source/Components/Shared/BottomButton.swift
@@ -29,7 +29,7 @@ class BottomButton: UIButton {
     }
     
     private func configUI(title: String) {
-        backgroundColor = .systemPink
+        backgroundColor = .pink100
         setTitle(title, for: .normal)
         setTitleColor(.white, for: .normal)
         titleLabel?.font = .systemFont(ofSize: 16, weight: .medium)
@@ -39,5 +39,15 @@ class BottomButton: UIButton {
     // MARK: - BottomButton Action
     func changeBottomButtonTitle(title: String) {
         setTitle(title, for: .normal)
+    }
+    
+    func changeBottomButton(isEnable: Bool?) {
+        if !isEnabled {
+            isEnabled = false
+            backgroundColor = .gray300
+        } else {
+            isEnabled = true
+            backgroundColor = .pink100
+        }
     }
 }

--- a/CatchMe/CatchMe/Source/Components/Shared/CustomTextField.swift
+++ b/CatchMe/CatchMe/Source/Components/Shared/CustomTextField.swift
@@ -1,0 +1,52 @@
+//
+//  CustomTextField.swift
+//  CatchMe
+//
+//  Created by SHIN YOON AH on 2021/07/08.
+//
+
+import UIKit
+
+import SnapKit
+
+class CustomTextField: UITextField {
+
+    // MARK: - Life Cycle
+    init(placeholder: String) {
+        super.init(frame: .zero)
+        setupLayout()
+        configUI(placeholder: placeholder)
+        removeAuto()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Custom Method
+    private func setupLayout() {
+        self.snp.makeConstraints { make in
+            make.height.equalTo(48)
+        }
+    }
+    
+    private func configUI(placeholder: String) {
+        backgroundColor = .black200
+        
+        layer.cornerRadius = 13
+        layer.borderWidth = 1
+        layer.borderColor = UIColor.clear.cgColor
+        
+        attributedPlaceholder = NSAttributedString(string: placeholder, attributes: [NSAttributedString.Key.foregroundColor : UIColor.gray400])
+        textColor = .white
+        font = .systemFont(ofSize: 16, weight: .medium)
+        setLeftPaddingPoints(17)
+    }
+    
+    private func removeAuto() {
+        self.autocorrectionType = .no
+        self.autocapitalizationType = .none
+        self.spellCheckingType = .no
+        self.textContentType = .none
+    }
+}

--- a/CatchMe/CatchMe/Source/Components/Shared/CustomTextField.swift
+++ b/CatchMe/CatchMe/Source/Components/Shared/CustomTextField.swift
@@ -11,7 +11,6 @@ import SnapKit
 
 class CustomTextField: UITextField {
 
-    // MARK: - Life Cycle
     init(placeholder: String) {
         super.init(frame: .zero)
         setupLayout()
@@ -23,7 +22,6 @@ class CustomTextField: UITextField {
         fatalError("init(coder:) has not been implemented")
     }
     
-    // MARK: - Custom Method
     private func setupLayout() {
         self.snp.makeConstraints { make in
             make.height.equalTo(48)
@@ -32,24 +30,26 @@ class CustomTextField: UITextField {
     
     private func configUI(placeholder: String) {
         backgroundColor = .black200
+        textColor = .white
         
         layer.cornerRadius = 13
         layer.borderWidth = 1
         layer.borderColor = UIColor.clear.cgColor
         
         attributedPlaceholder = NSAttributedString(string: placeholder, attributes: [NSAttributedString.Key.foregroundColor : UIColor.gray400])
-        textColor = .white
         font = .systemFont(ofSize: 16, weight: .medium)
+        
         setLeftPaddingPoints(17)
     }
     
     private func removeAuto() {
-        self.autocorrectionType = .no
-        self.autocapitalizationType = .none
-        self.spellCheckingType = .no
-        self.textContentType = .none
+        autocorrectionType = .no
+        autocapitalizationType = .none
+        spellCheckingType = .no
+        textContentType = .none
     }
     
+    // MARK: - TextField Action
     func setupOriginalLine() {
         layer.borderColor = UIColor.clear.cgColor
     }

--- a/CatchMe/CatchMe/Source/Components/Shared/CustomTextField.swift
+++ b/CatchMe/CatchMe/Source/Components/Shared/CustomTextField.swift
@@ -49,4 +49,12 @@ class CustomTextField: UITextField {
         self.spellCheckingType = .no
         self.textContentType = .none
     }
+    
+    func setupOriginalLine() {
+        layer.borderColor = UIColor.clear.cgColor
+    }
+    
+    func setupPinkLine() {
+        layer.borderColor = UIColor.pink100.cgColor
+    }
 }

--- a/CatchMe/CatchMe/Source/Extensions/UIView+Extension.swift
+++ b/CatchMe/CatchMe/Source/Extensions/UIView+Extension.swift
@@ -19,15 +19,25 @@ extension UIView {
         views.forEach { self.addSubview($0) }
     }
     
-    func fadeIn(duration: TimeInterval = 1.0, delay: TimeInterval = 0.0, completion: @escaping ((Bool) -> Void) = {(finished: Bool) -> Void in}) {
-        UIView.animate(withDuration: duration, delay: delay, options: UIView.AnimationOptions.curveEaseIn, animations: {
-            self.alpha = 1.0
-        }, completion: completion)
+    func fadeIn(duration: TimeInterval = 1.0,
+                delay: TimeInterval = 0.0,
+                completion: @escaping ((Bool) -> Void) = {(finished: Bool) -> Void in}) {
+        UIView.animate(withDuration: duration,
+                       delay: delay,
+                       options: .curveEaseIn,
+                       animations: {
+                        self.alpha = 1.0
+                       }, completion: completion)
     }
 
-    func fadeOut(duration: TimeInterval = 1.0, delay: TimeInterval = 3.0, completion: @escaping (Bool) -> Void = {(finished: Bool) -> Void in}) {
-        UIView.animate(withDuration: duration, delay: delay, options: UIView.AnimationOptions.curveEaseIn, animations: {
-            self.alpha = 0.0
-        }, completion: completion)
+    func fadeOut(duration: TimeInterval = 1.0,
+                 delay: TimeInterval = 3.0,
+                 completion: @escaping (Bool) -> Void = {(finished: Bool) -> Void in}) {
+        UIView.animate(withDuration: duration,
+                       delay: delay,
+                       options: .curveEaseIn,
+                       animations: {
+                        self.alpha = 0.0
+                       }, completion: completion)
     }
 }

--- a/CatchMe/CatchMe/Source/Extensions/UIView+Extension.swift
+++ b/CatchMe/CatchMe/Source/Extensions/UIView+Extension.swift
@@ -18,4 +18,16 @@ extension UIView {
     func addSubviews(_ views: [UIView]) {
         views.forEach { self.addSubview($0) }
     }
+    
+    func fadeIn(duration: TimeInterval = 1.0, delay: TimeInterval = 0.0, completion: @escaping ((Bool) -> Void) = {(finished: Bool) -> Void in}) {
+        UIView.animate(withDuration: duration, delay: delay, options: UIView.AnimationOptions.curveEaseIn, animations: {
+            self.alpha = 1.0
+        }, completion: completion)
+    }
+
+    func fadeOut(duration: TimeInterval = 1.0, delay: TimeInterval = 3.0, completion: @escaping (Bool) -> Void = {(finished: Bool) -> Void in}) {
+        UIView.animate(withDuration: duration, delay: delay, options: UIView.AnimationOptions.curveEaseIn, animations: {
+            self.alpha = 0.0
+        }, completion: completion)
+    }
 }

--- a/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
@@ -120,8 +120,14 @@ class AddCatchuVC: UIViewController {
         switch currentFlow {
         case Flow.select.rawValue:
             backButton.isHidden = true
+            
             secondFlowView.textField.text = ""
             secondFlowView.countLabel.text = "0/20"
+        case Flow.naming.rawValue:
+            backButton.isHidden = false
+            
+            thirdFlowView.isLock = false
+            thirdFlowView.lockButton.backgroundColor = .systemPink
         default:
             backButton.isHidden = false
         }
@@ -136,16 +142,18 @@ class AddCatchuVC: UIViewController {
             thirdFlowView.isHidden = true
             
             /// bottombutton Change
-            bottomButton.changeBottomButtonTitle(title: "잡았다!")
+            bottomButton.isEnabled = true
             bottomButton.changeBottomButton(isEnable: true)
+            bottomButton.changeBottomButtonTitle(title: "잡았다!")
         case Flow.naming.rawValue:
             /// 뷰 hidden
             firstFlowView.isHidden = true
             secondFlowView.isHidden = false
             thirdFlowView.isHidden = true
             
-            /// bottombutton Change
             secondFlowView.setImageViewColor(selectedIndex: firstFlowView.previousIndex)
+            
+            /// bottombutton Change
             bottomButton.changeBottomButtonTitle(title: "너로 정했다!")
             if secondFlowView.textField.hasText {
                 bottomButton.isEnabled = true
@@ -159,6 +167,9 @@ class AddCatchuVC: UIViewController {
             firstFlowView.isHidden = true
             secondFlowView.isHidden = true
             thirdFlowView.isHidden = false
+            
+            thirdFlowView.setImageViewColor(selectedIndex: firstFlowView.previousIndex)
+            thirdFlowView.setCharacterName(name: secondFlowView.textField.text ?? "")
             
             /// bottombutton Change
             bottomButton.changeBottomButtonTitle(title: "탄생!")

--- a/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
@@ -17,6 +17,7 @@ class AddCatchuVC: UIViewController {
     let backButton = BackButton()
     let pageControl = AddCatchuPageControl()
     let firstFlowView = FirstFlowView()
+    let bottomButton = BottomButton(title: "잡았다!")
     
     // MARK: - Life Cycle
     override func viewDidLoad() {
@@ -29,7 +30,7 @@ class AddCatchuVC: UIViewController {
     // MARK: - Custom Methods
     private func setupLayout() {
         view.addSubviews([xmarkButton, backButton, pageControl,
-                          firstFlowView])
+                          firstFlowView, bottomButton])
         
         xmarkButton.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide).inset(11)
@@ -48,10 +49,15 @@ class AddCatchuVC: UIViewController {
             make.height.equalTo(12)
         }
         
+        bottomButton.snp.makeConstraints { make in
+            make.bottom.equalToSuperview().inset(50)
+            make.leading.trailing.equalToSuperview().inset(28)
+        }
+        
         firstFlowView.snp.makeConstraints { make in
             make.top.equalTo(pageControl.snp.bottom).offset(32)
             make.leading.trailing.equalToSuperview()
-            make.height.equalTo(200)
+            make.bottom.equalTo(bottomButton.snp.top)
         }
     }
     

--- a/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
@@ -8,22 +8,18 @@
 import UIKit
 
 class AddCatchuVC: UIViewController {
+    // MARK: - lazy Properties
+    lazy var xmarkButton = XmarkButton(self)
+    
+    // MARK: - Properties
 
+    // MARK: - Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    // MARK: - Custom Methods
+    private func setupLayout() {
+        view.addSubviews([xmarkButton])
     }
-    */
-
 }

--- a/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
@@ -7,19 +7,64 @@
 
 import UIKit
 
+import SnapKit
+
 class AddCatchuVC: UIViewController {
     // MARK: - lazy Properties
     lazy var xmarkButton = XmarkButton(self)
     
     // MARK: - Properties
-
+    let backButton = BackButton()
+    let pageControl = AddCatchuPageControl()
+    let firstFlowView = FirstFlowView()
+    
     // MARK: - Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        setupLayout()
+        configUI()
+        setupButtonAction()
     }
     
     // MARK: - Custom Methods
     private func setupLayout() {
-        view.addSubviews([xmarkButton])
+        view.addSubviews([xmarkButton, backButton, pageControl,
+                          firstFlowView])
+        
+        xmarkButton.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(11)
+            make.trailing.equalToSuperview().inset(12)
+        }
+        
+        backButton.snp.makeConstraints { make in
+            make.top.equalTo(xmarkButton.snp.top)
+            make.leading.equalToSuperview().inset(11)
+        }
+        
+        pageControl.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).inset(75)
+            make.leading.equalToSuperview().inset(28)
+            make.width.equalTo(40)
+            make.height.equalTo(12)
+        }
+        
+        firstFlowView.snp.makeConstraints { make in
+            make.top.equalTo(pageControl.snp.bottom).offset(32)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(200)
+        }
+    }
+    
+    private func configUI() {
+        view.backgroundColor = .black
+        
+        pageControl.pages = 3
+    }
+    
+    private func setupButtonAction() {
+        let previousAction = UIAction { _ in
+            
+        }
+        backButton.addAction(previousAction, for: .touchUpInside)
     }
 }

--- a/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
@@ -61,8 +61,8 @@ class AddCatchuVC: UIViewController {
         }
         
         bottomButton.snp.makeConstraints { make in
-            make.bottom.equalToSuperview().inset(50)
             make.leading.trailing.equalToSuperview().inset(28)
+            make.bottom.equalToSuperview().inset(50)
         }
         
         firstFlowView.snp.makeConstraints { make in
@@ -116,6 +116,31 @@ class AddCatchuVC: UIViewController {
         bottomButton.addAction(nextAction, for: .touchUpInside)
     }
     
+    // MARK: - @objc
+    @objc
+    override func dismissKeyboard() {
+        view.endEditing(true)
+        
+        if currentFlow == Flow.naming.rawValue {
+            UIView.animate(withDuration: 0.2, animations: {
+                self.secondFlowView.characterImageView.transform = .identity
+                self.secondFlowView.textField.transform = .identity
+                self.secondFlowView.countLabel.transform = .identity
+            })
+            
+            if secondFlowView.textField.hasText {
+                bottomButton.isEnabled = true
+                bottomButton.changeBottomButton(isEnable: true)
+            } else {
+                bottomButton.isEnabled = false
+                bottomButton.changeBottomButton(isEnable: false)
+            }
+        }
+    }
+}
+
+// MARK: - Helper
+extension AddCatchuVC {
     private func changeBackButtonState() {
         switch currentFlow {
         case Flow.select.rawValue:
@@ -136,24 +161,25 @@ class AddCatchuVC: UIViewController {
     private func changeFlowViewState() {
         switch currentFlow {
         case Flow.select.rawValue:
-            /// 뷰 hidden
+            /// FlowView hidden
             firstFlowView.isHidden = false
             secondFlowView.isHidden = true
             thirdFlowView.isHidden = true
             
-            /// bottombutton Change
+            /// BottomButton Change
             bottomButton.isEnabled = true
             bottomButton.changeBottomButton(isEnable: true)
             bottomButton.changeBottomButtonTitle(title: "잡았다!")
         case Flow.naming.rawValue:
-            /// 뷰 hidden
+            /// FlowView hidden
             firstFlowView.isHidden = true
             secondFlowView.isHidden = false
             thirdFlowView.isHidden = true
             
+            /// View Setting
             secondFlowView.setImageViewColor(selectedIndex: firstFlowView.previousIndex)
             
-            /// bottombutton Change
+            /// BottomButton Change
             bottomButton.changeBottomButtonTitle(title: "너로 정했다!")
             if secondFlowView.textField.hasText {
                 bottomButton.isEnabled = true
@@ -163,39 +189,19 @@ class AddCatchuVC: UIViewController {
                 bottomButton.changeBottomButton(isEnable: false)
             }
         case Flow.complete.rawValue:
-            /// 뷰 hidden
+            /// FlowView hidden
             firstFlowView.isHidden = true
             secondFlowView.isHidden = true
             thirdFlowView.isHidden = false
             
+            /// View Setting
             thirdFlowView.setImageViewColor(selectedIndex: firstFlowView.previousIndex)
             thirdFlowView.setCharacterName(name: secondFlowView.textField.text ?? "")
             
-            /// bottombutton Change
+            /// BottomButton Change
             bottomButton.changeBottomButtonTitle(title: "탄생!")
-        default: break
-        }
-    }
-    
-    // MARK: - @objc
-    @objc
-    override func dismissKeyboard() {
-        view.endEditing(true)
-        
-        if currentFlow == 2 {
-            UIView.animate(withDuration: 0.2, animations: {
-                self.secondFlowView.characterImageView.transform = .identity
-                self.secondFlowView.textField.transform = .identity
-                self.secondFlowView.countLabel.transform = .identity
-            })
-            
-            if secondFlowView.textField.hasText {
-                bottomButton.isEnabled = true
-                bottomButton.changeBottomButton(isEnable: true)
-            } else {
-                bottomButton.isEnabled = false
-                bottomButton.changeBottomButton(isEnable: false)
-            }
+        default:
+            break
         }
     }
 }

--- a/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
@@ -24,6 +24,7 @@ class AddCatchuVC: UIViewController {
     let pageControl = AddCatchuPageControl()
     let firstFlowView = FirstFlowView()
     let secondFlowView = SecondFlowView()
+    let thirdFlowView = ThirdFlowView()
     let bottomButton = BottomButton(title: "잡았다!")
     
     var currentFlow = 1
@@ -39,7 +40,8 @@ class AddCatchuVC: UIViewController {
     // MARK: - Custom Methods
     private func setupLayout() {
         view.addSubviews([xmarkButton, backButton, pageControl,
-                          firstFlowView, secondFlowView, bottomButton])
+                          firstFlowView, secondFlowView, thirdFlowView,
+                          bottomButton])
         
         xmarkButton.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide).inset(11)
@@ -74,6 +76,12 @@ class AddCatchuVC: UIViewController {
             make.leading.trailing.equalToSuperview()
             make.bottom.equalTo(bottomButton.snp.top)
         }
+        
+        thirdFlowView.snp.makeConstraints { make in
+            make.top.equalTo(pageControl.snp.bottom).offset(32)
+            make.leading.trailing.equalToSuperview()
+            make.bottom.equalTo(bottomButton.snp.top)
+        }
     }
     
     private func configUI() {
@@ -83,6 +91,7 @@ class AddCatchuVC: UIViewController {
         
         backButton.isHidden = true
         secondFlowView.isHidden = true
+        thirdFlowView.isHidden = true
         
         hideKeyboardWhenTappedAround()
     }
@@ -124,13 +133,16 @@ class AddCatchuVC: UIViewController {
             /// 뷰 hidden
             firstFlowView.isHidden = false
             secondFlowView.isHidden = true
+            thirdFlowView.isHidden = true
             
             /// bottombutton Change
             bottomButton.changeBottomButtonTitle(title: "잡았다!")
+            bottomButton.changeBottomButton(isEnable: true)
         case Flow.naming.rawValue:
             /// 뷰 hidden
             firstFlowView.isHidden = true
             secondFlowView.isHidden = false
+            thirdFlowView.isHidden = true
             
             /// bottombutton Change
             secondFlowView.setImageViewColor(selectedIndex: firstFlowView.previousIndex)
@@ -146,6 +158,7 @@ class AddCatchuVC: UIViewController {
             /// 뷰 hidden
             firstFlowView.isHidden = true
             secondFlowView.isHidden = true
+            thirdFlowView.isHidden = false
             
             /// bottombutton Change
             bottomButton.changeBottomButtonTitle(title: "탄생!")
@@ -158,18 +171,20 @@ class AddCatchuVC: UIViewController {
     override func dismissKeyboard() {
         view.endEditing(true)
         
-        UIView.animate(withDuration: 0.2, animations: {
-            self.secondFlowView.characterImageView.transform = .identity
-            self.secondFlowView.textField.transform = .identity
-            self.secondFlowView.countLabel.transform = .identity
-        })
-        
-        if secondFlowView.textField.hasText {
-            bottomButton.isEnabled = true
-            bottomButton.changeBottomButton(isEnable: true)
-        } else {
-            bottomButton.isEnabled = false
-            bottomButton.changeBottomButton(isEnable: false)
+        if currentFlow == 2 {
+            UIView.animate(withDuration: 0.2, animations: {
+                self.secondFlowView.characterImageView.transform = .identity
+                self.secondFlowView.textField.transform = .identity
+                self.secondFlowView.countLabel.transform = .identity
+            })
+            
+            if secondFlowView.textField.hasText {
+                bottomButton.isEnabled = true
+                bottomButton.changeBottomButton(isEnable: true)
+            } else {
+                bottomButton.isEnabled = false
+                bottomButton.changeBottomButton(isEnable: false)
+            }
         }
     }
 }

--- a/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
@@ -77,7 +77,7 @@ class AddCatchuVC: UIViewController {
     }
     
     private func configUI() {
-        view.backgroundColor = .black
+        view.backgroundColor = .black100
         
         pageControl.pages = 3
         

--- a/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
@@ -83,6 +83,8 @@ class AddCatchuVC: UIViewController {
         
         backButton.isHidden = true
         secondFlowView.isHidden = true
+        
+        hideKeyboardWhenTappedAround()
     }
     
     private func setupButtonAction() {
@@ -109,6 +111,8 @@ class AddCatchuVC: UIViewController {
         switch currentFlow {
         case Flow.select.rawValue:
             backButton.isHidden = true
+            secondFlowView.textField.text = ""
+            secondFlowView.countLabel.text = "0/20"
         default:
             backButton.isHidden = false
         }
@@ -117,22 +121,55 @@ class AddCatchuVC: UIViewController {
     private func changeFlowViewState() {
         switch currentFlow {
         case Flow.select.rawValue:
+            /// 뷰 hidden
             firstFlowView.isHidden = false
             secondFlowView.isHidden = true
             
+            /// bottombutton Change
             bottomButton.changeBottomButtonTitle(title: "잡았다!")
         case Flow.naming.rawValue:
+            /// 뷰 hidden
             firstFlowView.isHidden = true
             secondFlowView.isHidden = false
             
+            /// bottombutton Change
             secondFlowView.setImageViewColor(selectedIndex: firstFlowView.previousIndex)
             bottomButton.changeBottomButtonTitle(title: "너로 정했다!")
-            /// textField에 따라서 isEnable 변경
+            if secondFlowView.textField.hasText {
+                bottomButton.isEnabled = true
+                bottomButton.changeBottomButton(isEnable: true)
+            } else {
+                bottomButton.isEnabled = false
+                bottomButton.changeBottomButton(isEnable: false)
+            }
         case Flow.complete.rawValue:
+            /// 뷰 hidden
             firstFlowView.isHidden = true
             secondFlowView.isHidden = true
+            
+            /// bottombutton Change
             bottomButton.changeBottomButtonTitle(title: "탄생!")
         default: break
+        }
+    }
+    
+    // MARK: - @objc
+    @objc
+    override func dismissKeyboard() {
+        view.endEditing(true)
+        
+        UIView.animate(withDuration: 0.2, animations: {
+            self.secondFlowView.characterImageView.transform = .identity
+            self.secondFlowView.textField.transform = .identity
+            self.secondFlowView.countLabel.transform = .identity
+        })
+        
+        if secondFlowView.textField.hasText {
+            bottomButton.isEnabled = true
+            bottomButton.changeBottomButton(isEnable: true)
+        } else {
+            bottomButton.isEnabled = false
+            bottomButton.changeBottomButton(isEnable: false)
         }
     }
 }

--- a/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
@@ -9,6 +9,12 @@ import UIKit
 
 import SnapKit
 
+enum Flow: Int {
+    case select = 1
+    case naming = 2
+    case complete = 3
+}
+
 class AddCatchuVC: UIViewController {
     // MARK: - lazy Properties
     lazy var xmarkButton = XmarkButton(self)
@@ -18,6 +24,8 @@ class AddCatchuVC: UIViewController {
     let pageControl = AddCatchuPageControl()
     let firstFlowView = FirstFlowView()
     let bottomButton = BottomButton(title: "잡았다!")
+    
+    var currentFlow = 1
     
     // MARK: - Life Cycle
     override func viewDidLoad() {
@@ -65,12 +73,51 @@ class AddCatchuVC: UIViewController {
         view.backgroundColor = .black
         
         pageControl.pages = 3
+        backButton.isHidden = true
     }
     
     private func setupButtonAction() {
         let previousAction = UIAction { _ in
-            
+            self.currentFlow -= 1
+            self.pageControl.selectedPage -= 1
+            self.changeBackButtonState()
+            self.changeFlowViewState()
         }
         backButton.addAction(previousAction, for: .touchUpInside)
+        
+        let nextAction = UIAction { _ in
+            if self.currentFlow != Flow.complete.rawValue {
+                self.currentFlow += 1
+                self.pageControl.selectedPage += 1
+                self.changeBackButtonState()
+                self.changeFlowViewState()
+            }
+        }
+        bottomButton.addAction(nextAction, for: .touchUpInside)
+    }
+    
+    private func changeBackButtonState() {
+        switch currentFlow {
+        case Flow.select.rawValue:
+            backButton.isHidden = true
+        default:
+            backButton.isHidden = false
+        }
+    }
+    
+    private func changeFlowViewState() {
+        switch currentFlow {
+        case Flow.select.rawValue:
+            firstFlowView.isHidden = false
+            bottomButton.changeBottomButtonTitle(title: "잡았다!")
+        case Flow.naming.rawValue:
+            firstFlowView.isHidden = true
+            bottomButton.changeBottomButtonTitle(title: "너로 정했다!")
+            /// textField에 따라서 isEnable 변경
+        case Flow.complete.rawValue:
+            firstFlowView.isHidden = true
+            bottomButton.changeBottomButtonTitle(title: "탄생!")
+        default: break
+        }
     }
 }

--- a/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/AddCatchuVC.swift
@@ -23,6 +23,7 @@ class AddCatchuVC: UIViewController {
     let backButton = BackButton()
     let pageControl = AddCatchuPageControl()
     let firstFlowView = FirstFlowView()
+    let secondFlowView = SecondFlowView()
     let bottomButton = BottomButton(title: "잡았다!")
     
     var currentFlow = 1
@@ -38,7 +39,7 @@ class AddCatchuVC: UIViewController {
     // MARK: - Custom Methods
     private func setupLayout() {
         view.addSubviews([xmarkButton, backButton, pageControl,
-                          firstFlowView, bottomButton])
+                          firstFlowView, secondFlowView, bottomButton])
         
         xmarkButton.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide).inset(11)
@@ -67,13 +68,21 @@ class AddCatchuVC: UIViewController {
             make.leading.trailing.equalToSuperview()
             make.bottom.equalTo(bottomButton.snp.top)
         }
+        
+        secondFlowView.snp.makeConstraints { make in
+            make.top.equalTo(pageControl.snp.bottom).offset(32)
+            make.leading.trailing.equalToSuperview()
+            make.bottom.equalTo(bottomButton.snp.top)
+        }
     }
     
     private func configUI() {
         view.backgroundColor = .black
         
         pageControl.pages = 3
+        
         backButton.isHidden = true
+        secondFlowView.isHidden = true
     }
     
     private func setupButtonAction() {
@@ -109,13 +118,19 @@ class AddCatchuVC: UIViewController {
         switch currentFlow {
         case Flow.select.rawValue:
             firstFlowView.isHidden = false
+            secondFlowView.isHidden = true
+            
             bottomButton.changeBottomButtonTitle(title: "잡았다!")
         case Flow.naming.rawValue:
             firstFlowView.isHidden = true
+            secondFlowView.isHidden = false
+            
+            secondFlowView.setImageViewColor(selectedIndex: firstFlowView.previousIndex)
             bottomButton.changeBottomButtonTitle(title: "너로 정했다!")
             /// textField에 따라서 isEnable 변경
         case Flow.complete.rawValue:
             firstFlowView.isHidden = true
+            secondFlowView.isHidden = true
             bottomButton.changeBottomButtonTitle(title: "탄생!")
         default: break
         }

--- a/CatchMe/CatchMe/Source/ViewControllers/ReportPopupVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/ReportPopupVC.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import SnapKit
+
 class ReportPopupVC: UIViewController {
     // MARK: - lazy Properties
     lazy var popupView = PopupView(date: date ?? "", vc: self)


### PR DESCRIPTION
### 관련 이슈
close #14 
close #16 
close #32 

### 구현/변경 사항 및 이유
캐츄 생성뷰를 구현했습니다.

### PR Point
캐츄 생성뷰가 한 화면에서 다양한 뷰들을 다뤄야해서 로직이 좀 복잡합니다. 
제가 복잡하지 않도록 정리해본다고 하긴 했는데, 이게 다른 사람이 읽을 때 괜찮은지 봐주셨으면 좋겠습니다.
또한 알기 쉽게 하기 위해서 enum를 사용했는데요, enum 사용이 지금 상황에서 적절했는지 모르겠어서 한 번 봐주셨으면 좋겠습니다.
-> 실행시켜보려면 Character에서 Is Inital Viewcontroller를 AddCatchuVC로 변경하면 됩니다.!

### 참고 사항

#### 1. **UIView+Extension에 fadein, fadeout 코드추가**
<img width="1063" alt="스크린샷 2021-07-08 오후 1 14 28" src="https://user-images.githubusercontent.com/55099365/124861382-6e429580-dfee-11eb-8664-136f8e434dfa.png">

#### 2. **CustomTextField추가**
<img width="377" alt="스크린샷 2021-07-08 오후 1 16 43" src="https://user-images.githubusercontent.com/55099365/124861535-bfeb2000-dfee-11eb-8d72-24fda2e67dd9.png">
이 TextField를 Shared에다가 넣어두었습니다.

```
Q. 밖에 선그리는건 어떻게 하나요?
A. setOriginalLine(), setPinkLine() 두가지를 넣어뒀습니다.
```
이렇게 쓰면 Line이 쇽 생깁니다. Original를 쓰면 원래처럼 선이 사라집니다.
<img width="633" alt="스크린샷 2021-07-08 오후 1 18 56" src="https://user-images.githubusercontent.com/55099365/124861717-0f315080-dfef-11eb-808a-381ed5d80295.png">


#### 3. **BackButton 생성자 추가**

<img width="704" alt="스크린샷 2021-07-08 오후 1 19 54" src="https://user-images.githubusercontent.com/55099365/124861789-30923c80-dfef-11eb-9787-be7d17c5acae.png">
BackButton의 용도가 pop이 아닐 수도 있더라구요. 
그럴경우에는 첫번째 init를 사용해서 들어간다음에 원하는대로 button에 addAction혹은 addTarget를 해서 사용하시면 될 것 같습니다.

```swift
 /// 원래 코드
 lazy var button = BackButton(self)
 /// 추가된 코드 
 let button = BackButton()
```

그냥 이렇게 쓰면 됩니다.