### PR TITLE
Feature/36 main card view layout fix

### DIFF
--- a/CatchMe/CatchMe/Resource/Storyboards/Main.storyboard
+++ b/CatchMe/CatchMe/Resource/Storyboards/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="3el-f5-fVg">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>

--- a/CatchMe/CatchMe/Source/Cells/MainCard/MainCardCVC.swift
+++ b/CatchMe/CatchMe/Source/Cells/MainCard/MainCardCVC.swift
@@ -24,14 +24,14 @@ class MainCardCVC: UICollectionViewCell {
     
     // MARK: - Custom Method
     func configUI() {
-        self.backgroundColor = .white
         self.layer.cornerRadius = 14
+        self.backgroundColor = .white
         characterBackView.backgroundColor = .systemIndigo
         characterImageView.backgroundColor = .cyan
         
         nameLabel.text = "캐치미캐치유캐치미를정말정말좋아하는캐츄"
         nameLabel.textColor = .black
-        nameLabel.font = UIFont.catchuRegularSystemFont(ofSize: 14)
+        nameLabel.font = .catchuRegularSystemFont(ofSize: 14)
         nameLabel.lineBreakMode = .byWordWrapping
         nameLabel.numberOfLines = 2
     }
@@ -51,9 +51,10 @@ class MainCardCVC: UICollectionViewCell {
         }
         
         nameLabel.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(14)
-            make.trailing.equalToSuperview().inset(14)
             make.top.equalTo(characterBackView.snp.bottom).offset(10)
+            make.leading.equalToSuperview().inset(14)
+            make.width.equalTo(127)
+            make.height.equalTo(36)
         }
     }
 }

--- a/CatchMe/CatchMe/Source/ViewControllers/MainCardVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/MainCardVC.swift
@@ -37,17 +37,17 @@ class MainCardVC: UIViewController {
         
         backButton.snp.makeConstraints { make in
             make.top.equalTo(view.snp.top).offset(55)
-            make.leading.equalTo(view.snp.leading).offset(14)
+            make.leading.equalToSuperview().offset(14)
         }
         
         nameLabel.snp.makeConstraints { make in
             make.top.equalTo(backButton.snp.bottom).offset(16)
-            make.leading.equalTo(view.snp.leading).offset(28)
+            make.leading.equalToSuperview().offset(UIScreen.main.hasNotch ? 28 : 24)
         }
         
         titleLabel.snp.makeConstraints { make in
             make.top.equalTo(nameLabel.snp.bottom).offset(6)
-            make.leading.equalTo(view.snp.leading).offset(28)
+            make.leading.equalToSuperview().offset(UIScreen.main.hasNotch ? 28 : 24)
         }
         
         popupButton.snp.makeConstraints { make in
@@ -57,23 +57,23 @@ class MainCardVC: UIViewController {
         }
         
         addButton.snp.makeConstraints { make in
+            make.top.equalTo(backButton.snp.bottom).offset(14)
+            make.trailing.equalToSuperview().inset(27)
             make.width.equalTo(72)
             make.height.equalTo(48)
-            make.trailing.equalTo(view.snp.trailing).inset(27)
-            make.top.equalTo(backButton.snp.bottom).offset(14)
         }
         
         alignButton.snp.makeConstraints { make in
-            make.width.height.equalTo(48)
-            make.trailing.equalTo(view.snp.trailing).inset(13)
             make.top.equalTo(addButton.snp.bottom).offset(27)
+            make.trailing.equalToSuperview().inset(13)
+            make.width.height.equalTo(48)
         }
         
         collectionView.snp.makeConstraints { make in
-            make.top.equalTo(view.snp.top).offset(260)
-            make.leading.equalTo(view.snp.leading).offset(29)
-            make.bottom.equalTo(view.snp.bottom)
-            make.trailing.equalTo(view.snp.trailing).inset(28)
+            make.top.equalToSuperview().offset(260)
+            make.leading.equalToSuperview().offset(UIScreen.main.hasNotch ? 28 : 24)
+            make.bottom.equalToSuperview()
+            make.trailing.equalToSuperview().inset(UIScreen.main.hasNotch ? 28 : 24)
         }
     }
     
@@ -82,11 +82,11 @@ class MainCardVC: UIViewController {
         
         nameLabel.text = "최고의대장피엠김해리 님"
         nameLabel.textColor = .white
-        nameLabel.font = UIFont.stringBoldSystemFont(ofSize: 14)
+        nameLabel.font = .stringBoldSystemFont(ofSize: 14)
         
         titleLabel.text = "캐츄 모아보기"
         titleLabel.textColor = .white
-        titleLabel.font = UIFont.stringBoldSystemFont(ofSize: 22)
+        titleLabel.font = .stringBoldSystemFont(ofSize: 22)
         
         popupButton.backgroundColor = .blue
         addButton.backgroundColor = .yellow

--- a/CatchMe/CatchMe/Source/ViewControllers/MainCardVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/MainCardVC.swift
@@ -18,6 +18,9 @@ class MainCardVC: UIViewController {
     let addButton = UIButton()
     let alignButton = UIButton()
     let topBackView = UIView()
+    let emptyImageView = UIImageView()
+    let emptyTitleLabel = UILabel()
+    let emptySubLabel = UILabel()
     
     let collectionViewFlowLayout = UICollectionViewFlowLayout()
     lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowLayout)
@@ -28,18 +31,18 @@ class MainCardVC: UIViewController {
         setupLayout()
         configUI()
         setupCollectionView()
+//        setupEmptyLayout()
     }
     
     //MARK: - Custom Method
     func setupLayout() {
-        view.addSubviews([topBackView, backButton, nameLabel,
-                          titleLabel,popupButton, addButton,
-                          alignButton,collectionView])
+        view.addSubviews([topBackView, collectionView, backButton,
+                          nameLabel, titleLabel,popupButton,
+                          addButton, alignButton])
         
         topBackView.snp.makeConstraints { make in
             make.top.equalToSuperview()
             make.leading.trailing.equalToSuperview()
-//            make.height.equalTo(UIScreen.main.hasNotch ? 230 : 190)
             make.bottom.equalTo(alignButton.snp.bottom)
         }
         
@@ -78,11 +81,9 @@ class MainCardVC: UIViewController {
         }
         
         collectionView.snp.makeConstraints { make in
-//            make.top.equalToSuperview().offset(260)
             make.top.equalTo(topBackView.snp.bottom)
-            make.leading.equalToSuperview().offset(UIScreen.main.hasNotch ? 28 : 24)
+            make.leading.trailing.equalToSuperview()
             make.bottom.equalToSuperview()
-            make.trailing.equalToSuperview().inset(UIScreen.main.hasNotch ? 28 : 24)
         }
     }
     
@@ -92,6 +93,7 @@ class MainCardVC: UIViewController {
         addButton.backgroundColor = .yellow
         alignButton.backgroundColor = .gray300
         topBackView.backgroundColor = .brown
+        emptyImageView.backgroundColor = .pink000
         
         nameLabel.text = "최고의대장피엠김해리 님"
         nameLabel.textColor = .white
@@ -100,6 +102,14 @@ class MainCardVC: UIViewController {
         titleLabel.text = "캐츄 모아보기"
         titleLabel.textColor = .white
         titleLabel.font = .stringBoldSystemFont(ofSize: 22)
+        
+        emptyTitleLabel.text = "캐츄를 추가해보세요!"
+        emptyTitleLabel.textColor = .gray300
+        emptyTitleLabel.font = .stringMediumSystemFont(ofSize: 20)
+        
+        emptySubLabel.text = "캐츄와 함께 다양한 내 모습을 기록해요"
+        emptySubLabel.textColor = .gray300
+        emptySubLabel.font = .stringRegularSystemFont(ofSize: 14)
     }
     
     func setupCollectionView() {
@@ -110,6 +120,27 @@ class MainCardVC: UIViewController {
         collectionView.setupCollectionViewNib(nib: MainCardCVC.identifier)
         collectionView.backgroundColor = .clear
         collectionView.showsVerticalScrollIndicator = false
+    }
+    
+    func setupEmptyLayout() {
+        view.addSubviews([emptyImageView, emptyTitleLabel, emptySubLabel])
+        
+        emptyImageView.snp.makeConstraints { make in
+            make.top.equalTo(topBackView.snp.bottom).offset(UIScreen.main.hasNotch ? 150 : 102)
+            make.centerX.equalToSuperview()
+            make.width.equalTo(115)
+            make.height.equalTo(116)
+        }
+        
+        emptyTitleLabel.snp.makeConstraints { make in
+            make.top.equalTo(emptyImageView.snp.bottom).offset(24)
+            make.centerX.equalToSuperview()
+        }
+        
+        emptySubLabel.snp.makeConstraints { make in
+            make.top.equalTo(emptyTitleLabel.snp.bottom).offset(7)
+            make.centerX.equalToSuperview()
+        }
     }
 }
 
@@ -146,6 +177,6 @@ extension MainCardVC: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        return UIEdgeInsets(top: 11, left: 0, bottom: 0, right: 0)
+        return UIEdgeInsets(top: 11, left: 29, bottom: 0, right: 28)
     }
 }

--- a/CatchMe/CatchMe/Source/ViewControllers/MainCardVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/MainCardVC.swift
@@ -37,12 +37,11 @@ class MainCardVC: UIViewController {
     //MARK: - Custom Method
     func setupLayout() {
         view.addSubviews([topBackView, collectionView, backButton,
-                          nameLabel, titleLabel,popupButton,
+                          nameLabel, titleLabel, popupButton,
                           addButton, alignButton])
         
         topBackView.snp.makeConstraints { make in
-            make.top.equalToSuperview()
-            make.leading.trailing.equalToSuperview()
+            make.top.leading.trailing.equalToSuperview()
             make.bottom.equalTo(alignButton.snp.bottom)
         }
         
@@ -82,8 +81,7 @@ class MainCardVC: UIViewController {
         
         collectionView.snp.makeConstraints { make in
             make.top.equalTo(topBackView.snp.bottom)
-            make.leading.trailing.equalToSuperview()
-            make.bottom.equalToSuperview()
+            make.leading.bottom.trailing.equalToSuperview()
         }
     }
     

--- a/CatchMe/CatchMe/Source/ViewControllers/MainCardVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/MainCardVC.swift
@@ -151,6 +151,7 @@ extension MainCardVC: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        // 서버 연결시 데이터가 있으면 setupLayout(), 없으면 setupEmptyLayout()
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MainCardCVC.identifier, for: indexPath) as? MainCardCVC else {
             return UICollectionViewCell()
         }

--- a/CatchMe/CatchMe/Source/ViewControllers/MainCardVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/MainCardVC.swift
@@ -17,6 +17,7 @@ class MainCardVC: UIViewController {
     let popupButton = UIButton()
     let addButton = UIButton()
     let alignButton = UIButton()
+    let topBackView = UIView()
     
     let collectionViewFlowLayout = UICollectionViewFlowLayout()
     lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowLayout)
@@ -31,9 +32,16 @@ class MainCardVC: UIViewController {
     
     //MARK: - Custom Method
     func setupLayout() {
-        view.addSubviews([backButton, nameLabel, titleLabel,
-                          popupButton, addButton, alignButton,
-                          collectionView])
+        view.addSubviews([topBackView, backButton, nameLabel,
+                          titleLabel,popupButton, addButton,
+                          alignButton,collectionView])
+        
+        topBackView.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.leading.trailing.equalToSuperview()
+//            make.height.equalTo(UIScreen.main.hasNotch ? 230 : 190)
+            make.bottom.equalTo(alignButton.snp.bottom)
+        }
         
         backButton.snp.makeConstraints { make in
             make.top.equalTo(view.snp.top).offset(55)
@@ -70,7 +78,8 @@ class MainCardVC: UIViewController {
         }
         
         collectionView.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(260)
+//            make.top.equalToSuperview().offset(260)
+            make.top.equalTo(topBackView.snp.bottom)
             make.leading.equalToSuperview().offset(UIScreen.main.hasNotch ? 28 : 24)
             make.bottom.equalToSuperview()
             make.trailing.equalToSuperview().inset(UIScreen.main.hasNotch ? 28 : 24)
@@ -79,6 +88,10 @@ class MainCardVC: UIViewController {
     
     func configUI() {
         view.backgroundColor = .black100
+        popupButton.backgroundColor = .blue
+        addButton.backgroundColor = .yellow
+        alignButton.backgroundColor = .gray300
+        topBackView.backgroundColor = .brown
         
         nameLabel.text = "최고의대장피엠김해리 님"
         nameLabel.textColor = .white
@@ -87,10 +100,6 @@ class MainCardVC: UIViewController {
         titleLabel.text = "캐츄 모아보기"
         titleLabel.textColor = .white
         titleLabel.font = .stringBoldSystemFont(ofSize: 22)
-        
-        popupButton.backgroundColor = .blue
-        addButton.backgroundColor = .yellow
-        alignButton.backgroundColor = .gray300
     }
     
     func setupCollectionView() {
@@ -137,6 +146,6 @@ extension MainCardVC: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        return UIEdgeInsets(top: 11, left: 0, bottom: 0, right: 0)
     }
 }


### PR DESCRIPTION
### 관련 이슈

close #36 
close #40 

### 구현/변경 사항 및 이유

MainCard 뷰 기기 대응 레이아웃 수정 및 empty state 레이아웃 구현

### PR Point

empty 레이아웃을 잡긴 했는데, 저런식으로 잡아두고 나중에 서버 붙일 때 분기처리해서 하는게 맞는걸까여...💨

### 참고 사항

일단 empty state일 때 레이아웃은 잡아뒀는데, 일단은 collectionView 레이아웃 잡은 것을 보이도록 주석처리해뒀습니다..
backgroundcolor = .brown 인 부분은 나중에 아래 shadow가 있는 scroll-rectangle을 넣으려구 잡아뒀슴다😎🥲
