### PR TITLE
Feature/96 login service

### DIFF
--- a/CatchMe/CatchMe.xcodeproj/project.pbxproj
+++ b/CatchMe/CatchMe.xcodeproj/project.pbxproj
@@ -42,6 +42,11 @@
 		ED63E889268A14E7000F058F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ED63E888268A14E7000F058F /* Assets.xcassets */; };
 		ED63E88C268A14E7000F058F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = ED63E88A268A14E7000F058F /* LaunchScreen.storyboard */; };
 		ED7283FE269CCAF500D19FD5 /* EditCatchuVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7283FD269CCAF500D19FD5 /* EditCatchuVC.swift */; };
+		ED728401269CFFED00D19FD5 /* LoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED728400269CFFED00D19FD5 /* LoginService.swift */; };
+		ED728404269D06EB00D19FD5 /* SigninRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED728403269D06EB00D19FD5 /* SigninRequest.swift */; };
+		ED728406269D073E00D19FD5 /* SignupRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED728405269D073E00D19FD5 /* SignupRequest.swift */; };
+		ED728408269D079E00D19FD5 /* SigninModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED728407269D079E00D19FD5 /* SigninModel.swift */; };
+		ED72840B269D090C00D19FD5 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED72840A269D090C00D19FD5 /* LoginViewModel.swift */; };
 		EDB431B226958D1F0008BFB4 /* FirstFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB431B126958D1F0008BFB4 /* FirstFlowView.swift */; };
 		EDB431B72695BA9F0008BFB4 /* CarouselCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB431B62695BA9F0008BFB4 /* CarouselCVC.swift */; };
 		EDB431BB2695F9200008BFB4 /* SecondFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB431BA2695F9200008BFB4 /* SecondFlowView.swift */; };
@@ -147,6 +152,11 @@
 		ED63E88B268A14E7000F058F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		ED63E88D268A14E7000F058F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		ED7283FD269CCAF500D19FD5 /* EditCatchuVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCatchuVC.swift; sourceTree = "<group>"; };
+		ED728400269CFFED00D19FD5 /* LoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginService.swift; sourceTree = "<group>"; };
+		ED728403269D06EB00D19FD5 /* SigninRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigninRequest.swift; sourceTree = "<group>"; };
+		ED728405269D073E00D19FD5 /* SignupRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupRequest.swift; sourceTree = "<group>"; };
+		ED728407269D079E00D19FD5 /* SigninModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigninModel.swift; sourceTree = "<group>"; };
+		ED72840A269D090C00D19FD5 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		EDB431B126958D1F0008BFB4 /* FirstFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstFlowView.swift; sourceTree = "<group>"; };
 		EDB431B62695BA9F0008BFB4 /* CarouselCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselCVC.swift; sourceTree = "<group>"; };
 		EDB431BA2695F9200008BFB4 /* SecondFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondFlowView.swift; sourceTree = "<group>"; };
@@ -407,6 +417,7 @@
 			children = (
 				ED63E89B268A1C56000F058F /* Extensions */,
 				ED63E89A268A1C54000F058F /* Models */,
+				ED728409269D08DD00D19FD5 /* ViewModels */,
 				ED63E89D268A1CB9000F058F /* Components */,
 				ED63E899268A1C4A000F058F /* Cells */,
 				ED63E895268A1B98000F058F /* ViewControllers */,
@@ -477,6 +488,7 @@
 		ED63E89A268A1C54000F058F /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				ED728402269D06C800D19FD5 /* Login */,
 				5B447CD226961D6400F79AB7 /* Character */,
 			);
 			path = Models;
@@ -530,12 +542,39 @@
 		ED63E89E268A1D78000F058F /* APIServices */ = {
 			isa = PBXGroup;
 			children = (
+				ED7283FF269CFFDB00D19FD5 /* Services */,
 				EDB72D4C269AE607003EE228 /* GeneralAPI.swift */,
 				EDB72D4E269AEB7B003EE228 /* NetworkLoggerPlugin.swift */,
 				EDB72D50269AEE60003EE228 /* UserData.swift */,
 				EDB72D52269AEF86003EE228 /* Login.swift */,
 			);
 			path = APIServices;
+			sourceTree = "<group>";
+		};
+		ED7283FF269CFFDB00D19FD5 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				ED728400269CFFED00D19FD5 /* LoginService.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
+		ED728402269D06C800D19FD5 /* Login */ = {
+			isa = PBXGroup;
+			children = (
+				ED728403269D06EB00D19FD5 /* SigninRequest.swift */,
+				ED728405269D073E00D19FD5 /* SignupRequest.swift */,
+				ED728407269D079E00D19FD5 /* SigninModel.swift */,
+			);
+			path = Login;
+			sourceTree = "<group>";
+		};
+		ED728409269D08DD00D19FD5 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				ED72840A269D090C00D19FD5 /* LoginViewModel.swift */,
+			);
+			path = ViewModels;
 			sourceTree = "<group>";
 		};
 		EDB431B52695BA800008BFB4 /* AddCatchu */ = {
@@ -805,6 +844,7 @@
 				EDD262C9269771BD00845F7B /* LoginVC.swift in Sources */,
 				EDBBFCD4269394EE00443077 /* UIColor+Extension.swift in Sources */,
 				ED3D6C402699A36800BB84C8 /* String+Extension.swift in Sources */,
+				ED728401269CFFED00D19FD5 /* LoginService.swift in Sources */,
 				EDD12CAE268EBDE400DF766A /* UIScreen+Extension.swift in Sources */,
 				EDD12CAA268EBCA000DF766A /* UIView+Extension.swift in Sources */,
 				5B08504D26919416008F40B2 /* NavigationBar.swift in Sources */,
@@ -817,13 +857,16 @@
 				EDD12CB2268EBE4E00DF766A /* UICollectionView+Extension.swift in Sources */,
 				2B0534CC26983FEB00646974 /* UILabel+Extension.swift in Sources */,
 				EDC19D9E2698B06D00F9E41B /* SignupTextFieldView.swift in Sources */,
+				ED72840B269D090C00D19FD5 /* LoginViewModel.swift in Sources */,
 				EDBBFCD226936F4600443077 /* CalendarCVC.swift in Sources */,
+				ED728404269D06EB00D19FD5 /* SigninRequest.swift in Sources */,
 				EDB431BF2696325E0008BFB4 /* ThirdFlowView.swift in Sources */,
 				ED63E880268A14E5000F058F /* AppDelegate.swift in Sources */,
 				EDC3780C2691D3CC007C53F2 /* ReportView.swift in Sources */,
 				EDD12CA4268EB80300DF766A /* CharacterVC.swift in Sources */,
 				EDD12CB4268EBE6D00DF766A /* UITableView+Extension.swift in Sources */,
 				5B0850602691A126008F40B2 /* CharacterTVC.swift in Sources */,
+				ED728406269D073E00D19FD5 /* SignupRequest.swift in Sources */,
 				5B447CEF2697146800F79AB7 /* CharacterFooterView.swift in Sources */,
 				EDBBFCE32693996F00443077 /* UIFont+Extension.swift in Sources */,
 				EDBDC80A269585F800CDF1B2 /* CatchuTitleView.swift in Sources */,
@@ -838,6 +881,7 @@
 				EDD12CB0268EBE1600DF766A /* UITextField+Extension.swift in Sources */,
 				EDC19D9126983C7100F9E41B /* UIButton+Extension.swift in Sources */,
 				5B447CDA269628D900F79AB7 /* Activity.swift in Sources */,
+				ED728408269D079E00D19FD5 /* SigninModel.swift in Sources */,
 				5B447CBD2694D3D100F79AB7 /* CharacterPopupView.swift in Sources */,
 				EDD12CAC268EBD2200DF766A /* UIViewController+Extension.swift in Sources */,
 				2B3654E12691ACBC002C2C5C /* CharacterCVC.swift in Sources */,

--- a/CatchMe/CatchMe/Resource/APIServices/GeneralAPI.swift
+++ b/CatchMe/CatchMe/Resource/APIServices/GeneralAPI.swift
@@ -9,5 +9,7 @@ import Foundation
 
 struct GeneralAPI {
     static let baseURL = "http://52.14.194.163:5000"
+    /// token for connecting server
+    static let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7ImlkIjoiNjBlNWQzMTE0ZjM3ZTliMjUyYzYwOGJlIn0sImlhdCI6MTYyNjEzNjY1NywiZXhwIjoxNjI3MzQ2MjU3fQ.hWhuKkTj_Les5M1Q1puzZonW0qxeSJ0YeDC3CmtyKpM"
     static var isFirstConnect = true
 }

--- a/CatchMe/CatchMe/Resource/APIServices/Login.swift
+++ b/CatchMe/CatchMe/Resource/APIServices/Login.swift
@@ -19,10 +19,9 @@ class Login: NSObject {
         return flag
     }
     
-    func setLogin(name:String, token: String) {
+    func setLogin(token: String) {
         let def = UserDefaults.standard
         UserData.set(token, forKey: .accessToken)
-        UserData.set(name, forKey: .userName)
         
         def.set(true, forKey: login)
         def.synchronize()

--- a/CatchMe/CatchMe/Resource/APIServices/Services/LoginService.swift
+++ b/CatchMe/CatchMe/Resource/APIServices/Services/LoginService.swift
@@ -1,0 +1,56 @@
+//
+//  LoginService.swift
+//  CatchMe
+//
+//  Created by SHIN YOON AH on 2021/07/13.
+//
+
+import Moya
+
+enum LoginService {
+    case signUp(param: SignupRequest)
+    case signIn(param: SigninRequest)
+}
+
+extension LoginService: TargetType {
+    public var baseURL: URL {
+        return URL(string: GeneralAPI.baseURL)!
+    }
+    
+    var path: String {
+        switch self {
+        case .signUp:
+            return "/user/signup"
+        case .signIn:
+            return "/user/login"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .signUp,
+             .signIn:
+            return .post
+        }
+    }
+    
+    var sampleData: Data {
+        return "@@".data(using: .utf8)!
+    }
+    
+    var task: Task {
+        switch self {
+        case .signUp(let param):
+            return .requestJSONEncodable(param)
+        case .signIn(let param):
+            return .requestJSONEncodable(param)
+        }
+    }
+    
+    var headers: [String: String]? {
+        switch self {
+        default:
+            return ["Content-Type": "application/json"]
+        }
+    }
+}

--- a/CatchMe/CatchMe/Resource/Info.plist
+++ b/CatchMe/CatchMe/Resource/Info.plist
@@ -47,7 +47,7 @@
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
-					<string>Character</string>
+					<string>Login</string>
 				</dict>
 			</array>
 		</dict>

--- a/CatchMe/CatchMe/Resource/Storyboards/Login.storyboard
+++ b/CatchMe/CatchMe/Resource/Storyboards/Login.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="za0-LI-5Yn">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
@@ -18,10 +18,11 @@
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
+                    <navigationItem key="navigationItem" id="dLs-ov-Amv"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="104" y="126"/>
+            <point key="canvasLocation" x="1042.4000000000001" y="125.4872563718141"/>
         </scene>
         <!--SignupVC-->
         <scene sceneID="ANI-vZ-VwR">
@@ -36,7 +37,25 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ujN-jK-VQ3" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="996" y="125"/>
+            <point key="canvasLocation" x="1935.2" y="124.58770614692655"/>
+        </scene>
+        <!--LoginNavi-->
+        <scene sceneID="4QC-cX-ky3">
+            <objects>
+                <navigationController title="LoginNavi" automaticallyAdjustsScrollViewInsets="NO" id="za0-LI-5Yn" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="8TA-td-EXr">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="Y6W-OH-hqX" kind="relationship" relationship="rootViewController" id="kR8-wa-a6E"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="r2X-Pf-Xp0" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="103.2" y="125.4872563718141"/>
         </scene>
     </scenes>
     <resources>

--- a/CatchMe/CatchMe/Source/Components/Login/TextFieldView.swift
+++ b/CatchMe/CatchMe/Source/Components/Login/TextFieldView.swift
@@ -25,9 +25,8 @@ class TextFieldView: UIView {
     var logoImageView = UIImageView()
     var isAuto = true
     
-    // MARK: - Dummy Data
-    let id = "tlsdbsdk0525"
-    let pw = "catchme"
+    // MARK: - Connect Server
+    let viewModel = LoginViewModel.shared
 
     // MARK: - Life Cycle
     init(logo: UIImageView) {
@@ -167,21 +166,24 @@ class TextFieldView: UIView {
         let loginAction = UIAction { _ in
             if let emailText = self.emailTextField.text,
                let pwText = self.passwordTextField.text {
-                if emailText != self.id {
-                    self.emailMessageLabel.isHidden = false
-                } else if pwText != self.pw {
-                    self.passwordMessageLabel.isHidden = false
-                } else {
-                    /// 로그인 성공 로직
-                    self.emailMessageLabel.isHidden = true
-                    self.passwordMessageLabel.isHidden = true
-                    
-                    UIView.animate(withDuration: 0.2, animations: {
-                        self.transform = .identity
-                    })
-                    
-                    self.logoImageView.fadeIn()
-                    self.passwordTextField.resignFirstResponder()
+                self.viewModel.dispatchLogin(email: emailText, password: pwText) { result in
+                    print(result)
+                    switch result {
+                    case 200:
+                        self.emailMessageLabel.isHidden = true
+                        self.passwordMessageLabel.isHidden = true
+                        
+                        UIView.animate(withDuration: 0.2, animations: {
+                            self.transform = .identity
+                        })
+                        
+                        self.logoImageView.fadeIn()
+                        self.passwordTextField.resignFirstResponder()
+                    case 412:
+                        self.passwordMessageLabel.isHidden = false
+                    default:
+                        self.emailMessageLabel.isHidden = false
+                    }
                 }
             }
         }

--- a/CatchMe/CatchMe/Source/Components/Login/TextFieldView.swift
+++ b/CatchMe/CatchMe/Source/Components/Login/TextFieldView.swift
@@ -169,7 +169,6 @@ class TextFieldView: UIView {
             if let emailText = self.emailTextField.text,
                let pwText = self.passwordTextField.text {
                 self.viewModel.dispatchLogin(email: emailText, password: pwText) { result in
-                    print(result)
                     switch result {
                     case 200:
                         self.emailMessageLabel.isHidden = true

--- a/CatchMe/CatchMe/Source/Components/Login/TextFieldView.swift
+++ b/CatchMe/CatchMe/Source/Components/Login/TextFieldView.swift
@@ -23,14 +23,16 @@ class TextFieldView: UIView {
     let secureButton = UIButton()
     
     var logoImageView = UIImageView()
+    var rootVC = UIViewController()
     var isAuto = true
     
     // MARK: - Connect Server
     let viewModel = LoginViewModel.shared
 
     // MARK: - Life Cycle
-    init(logo: UIImageView) {
+    init(logo: UIImageView, vc: UIViewController) {
         super.init(frame: .zero)
+        rootVC = vc
         logoImageView = logo
         setupLayout()
         configUI()
@@ -188,6 +190,12 @@ class TextFieldView: UIView {
             }
         }
         loginButton.addAction(loginAction, for: .touchUpInside)
+        
+        let signupAction = UIAction { _ in
+            guard let vc = self.rootVC.storyboard?.instantiateViewController(withIdentifier: "SignupVC") as? SignupVC else { return }
+            self.rootVC.navigationController?.pushViewController(vc, animated: true)
+        }
+        memberButton.addAction(signupAction, for: .touchUpInside)
     }
 }
 

--- a/CatchMe/CatchMe/Source/Models/Login/SigninModel.swift
+++ b/CatchMe/CatchMe/Source/Models/Login/SigninModel.swift
@@ -1,0 +1,21 @@
+//
+//  SigninModel.swift
+//  CatchMe
+//
+//  Created by SHIN YOON AH on 2021/07/13.
+//
+
+import Foundation
+
+// MARK: - SigninModel
+struct SigninModel: Codable {
+    let status: Int
+    let success: Bool
+    let message: String
+    let data: LoginData?
+}
+
+// MARK: - DataClass
+struct LoginData: Codable {
+    let token: String
+}

--- a/CatchMe/CatchMe/Source/Models/Login/SigninRequest.swift
+++ b/CatchMe/CatchMe/Source/Models/Login/SigninRequest.swift
@@ -1,0 +1,18 @@
+//
+//  SigninRequest.swift
+//  CatchMe
+//
+//  Created by SHIN YOON AH on 2021/07/13.
+//
+
+import Foundation
+
+struct SigninRequest: Codable {
+    var email: String
+    var password: String
+    
+    init(_ email: String, _ password: String) {
+        self.email = email
+        self.password = password
+    }
+}

--- a/CatchMe/CatchMe/Source/Models/Login/SignupRequest.swift
+++ b/CatchMe/CatchMe/Source/Models/Login/SignupRequest.swift
@@ -1,0 +1,18 @@
+//
+//  SignupRequest.swift
+//  CatchMe
+//
+//  Created by SHIN YOON AH on 2021/07/13.
+//
+
+import Foundation
+
+struct SignupRequest: Codable {
+    var email: String
+    var password: String
+    
+    init(_ email: String, _ password: String) {
+        self.email = email
+        self.password = password
+    }
+}

--- a/CatchMe/CatchMe/Source/ViewControllers/LoginVC.swift
+++ b/CatchMe/CatchMe/Source/ViewControllers/LoginVC.swift
@@ -11,7 +11,7 @@ import SnapKit
 
 class LoginVC: UIViewController {
     // MARK: - Lazy Properties
-    lazy var textFieldView = TextFieldView(logo: logoImageView)
+    lazy var textFieldView = TextFieldView(logo: logoImageView, vc: self)
     
     // MARK: - Properties
     let logoImageView = UIImageView()
@@ -41,6 +41,8 @@ class LoginVC: UIViewController {
     }
     
     private func configUI() {
+        navigationController?.setNavigationBarHidden(true, animated: false)
+        
         view.backgroundColor = .black100
         logoImageView.image = UIImage(named: "logoImage")
         logoImageView.contentMode = .scaleAspectFit

--- a/CatchMe/CatchMe/Source/ViewModels/LoginViewModel.swift
+++ b/CatchMe/CatchMe/Source/ViewModels/LoginViewModel.swift
@@ -30,11 +30,15 @@ class LoginViewModel {
                        let dataSuccess = self.signinModel?.success {
                         if text == "비밀번호가 일치하지 않습니다." && !dataSuccess {
                             success = 412
-                       } else if !dataSuccess {
+                        } else if !dataSuccess {
                             success = 400
-                       } else {
+                        } else {
                             success = 200
-                       }
+                            
+                            if let token = self.signinModel?.data?.token {
+                                Login.shared.setLogin(token: token)
+                            }
+                        }
                     }
                     
                     completion(success)

--- a/CatchMe/CatchMe/Source/ViewModels/LoginViewModel.swift
+++ b/CatchMe/CatchMe/Source/ViewModels/LoginViewModel.swift
@@ -1,0 +1,50 @@
+//
+//  LoginViewModel.swift
+//  CatchMe
+//
+//  Created by SHIN YOON AH on 2021/07/13.
+//
+
+import UIKit
+
+import Moya
+
+class LoginViewModel {
+    static var shared: LoginViewModel = LoginViewModel()
+    
+    private let authProvider = MoyaProvider<LoginService>(plugins: [NetworkLoggerPlugin(verbose: true)])
+    private var signinModel: SigninModel?
+    
+    // MARK: - POST /user/login
+    func dispatchLogin(email: String, password: String, completion: @escaping ((Int) -> Void)) {
+        var success = 0
+        let param = SigninRequest.init(email, password)
+        
+        authProvider.request(.signIn(param: param)) { response in
+            switch response {
+            case .success(let result):
+                do {
+                    self.signinModel = try result.map(SigninModel.self)
+                    
+                    if let text = self.signinModel?.message,
+                       let dataSuccess = self.signinModel?.success {
+                        if text == "비밀번호가 일치하지 않습니다." && !dataSuccess {
+                            success = 412
+                       } else if !dataSuccess {
+                            success = 400
+                       } else {
+                            success = 200
+                       }
+                    }
+                    
+                    completion(success)
+                } catch(let err) {
+                    print(err.localizedDescription)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                success = 500
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 관련 이슈

close #96 

### 구현/변경 사항 및 이유

로그인 뷰 서버 연결을 완료했습니다.

### PR Point

로그인 뷰에서 바로 서버를 통신하지 않고 viewmodel를 만들어서 viewModel 함수를 통해서 서버 통신할 수 있도록 해주었습니다.
서버 통신이 조금 어려운 부분들이 많아서 이해하기에 어려울 수 있기에 그런 부분들이 생기면 바로 질문 부탁드리겠습니다.
깃헙으로 질문가능, 슬랙으로 질문가능, 직접 질 문 가 능.

### 참고 사항

GeneralAPI에 token를 일단 넣어뒀습니다.중간에 token값을 가져와야하는 상황에서 사용하시면 됩니다. -> 서버 끝나고 플로우 연결까지 하면 지울 예정
아직 회원가입은 안했기때문에 signup부분 + signupRequest는 굳이 보지 않아도 됩니다.
